### PR TITLE
Fixing debug log print when checking package version. Fixes #11

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"time"
 
@@ -34,7 +33,7 @@ func checkVersion() (*checkVersionResult, error) {
 	// Get the latest version details from Github release
 	gh := github.NewClient(client)
 	releases, _, err := gh.Repositories.ListReleases(context.Background(), RepoOwner, RepoName, nil)
-	if err != nil {
+	if err != nil || len(releases) == 0 {
 		return &checkVersionResult{}, err
 	}
 
@@ -42,7 +41,6 @@ func checkVersion() (*checkVersionResult, error) {
 	// ie. v0.0.1 -> 0.0.1
 	latest := releases[0]
 	latestVersion := (*latest.TagName)[1:]
-	log.Print(latestVersion)
 
 	return &checkVersionResult{
 		LatestVersion: latestVersion,


### PR DESCRIPTION
```
$ go build -o sam -ldflags "-X main.version=0.1.0"

$ ./sam --version
sam version 0.1.0

```