### PR TITLE
New goformation version removing unnecessary tag reading. Fixes #30

### DIFF
--- a/validate_test.go
+++ b/validate_test.go
@@ -129,7 +129,7 @@ var _ = Describe("sam", func() {
 			Context("with a !Ref lookup variable", func() {
 				It("should have an environment variable named REF_ENV_VAR", func() {
 					Expect(f3.EnvironmentVariables()).To(HaveLen(1))
-					Expect(f3.EnvironmentVariables()).To(HaveKeyWithValue("REF_ENV_VAR", ""))
+					Expect(f3.EnvironmentVariables()).To(HaveKeyWithValue("REF_ENV_VAR", "ExampleParameter"))
 				})
 			})
 
@@ -145,7 +145,7 @@ var _ = Describe("sam", func() {
 			Context("with a !Sub variable value that contains a non-existant reference", func() {
 				It("should have an environment variable named SUB_REF_ENV_VAR", func() {
 					Expect(f5.EnvironmentVariables()).To(HaveLen(1))
-					Expect(f5.EnvironmentVariables()).To(HaveKeyWithValue("SUB_REF_ENV_VAR", "Hello-"))
+					Expect(f5.EnvironmentVariables()).To(HaveKeyWithValue("SUB_REF_ENV_VAR", "Hello-${ThisReferenceDoesntExist}"))
 				})
 			})
 
@@ -196,7 +196,6 @@ var _ = Describe("sam", func() {
 			})
 
 		})
-
 
 		Context("with non-resource sections in CloudFormation template", func() {
 

--- a/vendor/github.com/awslabs/goformation/unmarshal.go
+++ b/vendor/github.com/awslabs/goformation/unmarshal.go
@@ -13,24 +13,6 @@ func unmarshal(input []byte) (Template, error) {
 
 	var source = input
 	var error error
-
-	util.LogDebug(-1, "Unmarshalling", "Processing intrinsic functions")
-	for error == nil {
-		var tmpSource []byte
-		tmpSource, error = processIntrinsicFunctions(source)
-		if error == nil {
-			source = tmpSource
-		}
-	}
-
-	// If the error is ErrNoIntrinsicFunctionFound then it just means there are no more functions to process.
-	if error != ErrNoIntrinsicFunctionFound {
-		util.LogError(-1, "Unmarshalling", "An error occurred when processing the intrinsic functions")
-		util.LogError(-1, "Unmarshalling", "%s", error.Error())
-		return nil, error
-	}
-
-	error = nil
 	template := &unmarshalledTemplate{}
 
 	if err := yaml.Unmarshal(source, template); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -193,10 +193,10 @@
 			"revisionTime": "2017-07-27T22:25:20Z"
 		},
 		{
-			"checksumSHA1": "aUFIq9ox4/EzdRM7HTFXHTYU/5I=",
+			"checksumSHA1": "gOVYnq9xL1IsjuWkKPz73EJzFk4=",
 			"path": "github.com/awslabs/goformation",
-			"revision": "1dae6647ec1c8a79e8529d257c11953607bba524",
-			"revisionTime": "2017-08-13T16:29:21Z"
+			"revision": "58609f21dfe3998bd435d35652b629f749607d30",
+			"revisionTime": "2017-08-13T17:56:29Z"
 		},
 		{
 			"checksumSHA1": "H5Ps9SpE0mLJ8JaLQPKcj4wRScY=",
@@ -883,5 +883,5 @@
 			"revisionTime": "2017-02-08T14:18:51Z"
 		}
 	],
-	"rootPath": "github.com/paulmaddox/aws-sam-local"
+	"rootPath": "github.com/awslabs/aws-sam-local"
 }


### PR DESCRIPTION
Test suite:
```
aws-sam-local$ go test
Running Suite: AwsSamLocal Suite
================================
Random Seed: 1502647868
Will run 30 of 30 specs

••••••••••••••••••••••••••••••
Ran 30 of 30 Specs in 0.000 seconds
SUCCESS! -- 30 Passed | 0 Failed | 0 Pending | 0 Skipped PASS
ok      github.com/awslabs/aws-sam-local        3.051s
```

Execution of `start-api`:

```
2017/08/13 20:13:16 Connected to Docker 1.30
2017/08/13 20:13:16 Successfully parsed ../goformation/test-resources/api-backend.yaml (version 2010-09-09)
2017/08/13 20:13:16 Fetching lambci/lambda:nodejs image for nodejs runtime...
nodejs: Pulling from lambci/lambda
Digest: sha256:a868b2344ef5c6037fc2834e1d0abc014f494ec446b0cd224d13ec6836f30d52
Status: Image is up to date for lambci/lambda:nodejs
2017/08/13 20:13:18 Fetching lambci/lambda:nodejs4.3 image for nodejs4.3 runtime...
nodejs4.3: Pulling from lambci/lambda
Digest: sha256:6af9d18a022b22a5a93bcd5aca0dd1a8e837a0cd9d8940cc62ae4edc6747f517
Status: Image is up to date for lambci/lambda:nodejs4.3
2017/08/13 20:13:21 Fetching lambci/lambda:nodejs4.3 image for nodejs4.3 runtime...
nodejs4.3: Pulling from lambci/lambda
Digest: sha256:6af9d18a022b22a5a93bcd5aca0dd1a8e837a0cd9d8940cc62ae4edc6747f517
Status: Image is up to date for lambci/lambda:nodejs4.3

Mounting index.get (nodejs) at http://127.0.0.1:3000/resource/{resourceId} [GET]
Mounting index.put (nodejs4.3) at http://127.0.0.1:3000/resource/{resourceId} [PUT]
Mounting index.delete (nodejs4.3) at http://127.0.0.1:3000/resource/{resourceId} [DELETE]

You can now browse to the above endpoints to invoke your functions.
You do not need to restart/reload SAM CLI while working on your functions,
changes will be reflected instantly/automatically. You only need to restart
SAM CLI if you update your AWS SAM template.
```