### PR TITLE
If the 'body' returned by a Lambda function is a number, don't choke.

### DIFF
--- a/start.go
+++ b/start.go
@@ -184,7 +184,7 @@ func start(c *cli.Context) {
 						proxy := &struct {
 							StatusCode int               `json:"statusCode"`
 							Headers    map[string]string `json:"headers"`
-							Body       string            `json:"body"`
+							Body       json.Number       `json:"body"`
 						}{}
 
 						if err := json.Unmarshal(result, proxy); err != nil || (proxy.StatusCode == 0 && len(proxy.Headers) == 0 && proxy.Body == "") {


### PR DESCRIPTION
This uses the json encoding package json.Number type to transparently
work with both a number and/or a string. If it's a number, the json
encoding will convert it to a string.

See:
http://igorsobreira.com/2015/04/11/decoding-json-numbers-into-strings-in-go.html

Fixes #38.