### PR TITLE
Fix typo in HOWTO under the Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ $ sam deploy --template-file ./packaged.yaml --stack-name mystack --capabilities
 
 ## Getting started
 
-* Check out ![HOWTO Guide](HOWTO.md) section for more details
+* Check out [HOWTO Guide](HOWTO.md) section for more details
 
 ## Advanced
 


### PR DESCRIPTION

Before
![before](https://user-images.githubusercontent.com/1467223/29285587-cda8cc06-80e3-11e7-90d7-a31d6cc5e87c.jpeg)


After
![after](https://user-images.githubusercontent.com/1467223/29285593-d399ea46-80e3-11e7-99f2-ab247e930402.jpeg)
