### PR TITLE
Only use the last line of stdout for the JSON result

### DIFF
--- a/start.go
+++ b/start.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -176,6 +177,14 @@ func start(c *cli.Context) {
 							w.Write([]byte(`{ "message": "Internal server error" }`))
 							wg.Done()
 							return
+						}
+
+						// We only want the last line of stdout, because it's possible that
+						// the function may have written directly to stdout using
+						// System.out.println or similar, before docker-lambda output the result
+						lastNewlineIx := bytes.LastIndexByte(bytes.TrimRight(result, "\n"), '\n')
+						if lastNewlineIx > 0 {
+							result = result[lastNewlineIx:]
 						}
 
 						// At this point, we need to see whether the response is in the format


### PR DESCRIPTION
The user's function may have emitted text directly to the Docker container's stdout using System.out.println or similar – this won't parse as JSON.

As the function result is always a JSON string, and it's the last thing written to stdout, then we just want to use the last non-empty line. This is the same functionality as that used by the docker-lambda test runner: https://github.com/lambci/docker-lambda/blob/92f59a60884a1809d94046e3555a39f6e0539eab/index.js#L59-L61

cc @sanathkr  