### PR TITLE
Support for changing Docker Volume Basedir

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
             - [Combination of Shell and Environment Variable file](#combination-of-shell-and-environment-variable-file)
         - [Identifying local execution from Lambda function code](#identifying-local-execution-from-lambda-function-code)
         - [Local Logging](#local-logging)
+        - [Remote Docker](#remote-docker)
     - [Project Status](#project-status)
     - [Contributing](#contributing)
     - [A special thank you](#a-special-thank-you)
@@ -370,6 +371,22 @@ Example:
 ```bash
 $ sam local invoke --log-file ./output.log
 ```
+
+
+### Remote Docker
+Sam Local loads the function code using Docker Volume. As a result, The project directory must be pre-mounted on the remote host where the Docker is running.
+
+If mounted, you can use the remote docker normally using `--docker-volume-basedir` or environment variable `SAM_DOCKER_VOLUME_BASEDIR`.
+
+Example - Docker Toolbox (Windows):
+
+When you install and run Docker Toolbox, the Linux VM with Docker is automatically installed in the virtual box.
+
+The /c/ path for this Linux VM is automatically shared with C:\ on the host machine.
+```powershell
+sam local invoke --docker-volume-basedir /c/Users/shlee322/projects/test "Ratings"
+```
+
 
 ## Project Status
   

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ $ sam local invoke --log-file ./output.log
 
 
 ### Remote Docker
-Sam Local loads the function code using Docker Volume. As a result, The project directory must be pre-mounted on the remote host where the Docker is running.
+Sam Local loads function code by mounting filesystem to a Docker Volume. As a result, The project directory must be pre-mounted on the remote host where the Docker is running.
 
 If mounted, you can use the remote docker normally using `--docker-volume-basedir` or environment variable `SAM_DOCKER_VOLUME_BASEDIR`.
 

--- a/invoke.go
+++ b/invoke.go
@@ -117,7 +117,7 @@ func invoke(c *cli.Context) {
 		funcEnvVarsOverrides = map[string]string{}
 	}
 
-        baseDir := c.String("volume-basedir")
+        baseDir := c.String("docker-volume-basedir")
         if baseDir == "" {
             baseDir = filepath.Dir(filename)
         }

--- a/invoke.go
+++ b/invoke.go
@@ -117,10 +117,15 @@ func invoke(c *cli.Context) {
 		funcEnvVarsOverrides = map[string]string{}
 	}
 
+        baseDir := c.String("volume-basedir")
+        if baseDir == "" {
+            baseDir = filepath.Dir(filename)
+        }
+
 	runt, err := NewRuntime(NewRuntimeOpt{
 		Function:         function,
 		EnvVarsOverrides: funcEnvVarsOverrides,
-		Basedir:          filepath.Dir(filename),
+		Basedir:          baseDir,
 		DebugPort:        c.String("debug-port"),
 	})
 	if err != nil {

--- a/invoke.go
+++ b/invoke.go
@@ -118,15 +118,18 @@ func invoke(c *cli.Context) {
 	}
 
 	baseDir := c.String("docker-volume-basedir")
+	checkWorkingDirExist := false
 	if baseDir == "" {
 		baseDir = filepath.Dir(filename)
+		checkWorkingDirExist = true
 	}
 
 	runt, err := NewRuntime(NewRuntimeOpt{
-		Function:         function,
-		EnvVarsOverrides: funcEnvVarsOverrides,
-		Basedir:          baseDir,
-		DebugPort:        c.String("debug-port"),
+		Function:             function,
+		EnvVarsOverrides:     funcEnvVarsOverrides,
+		Basedir:              baseDir,
+		CheckWorkingDirExist: checkWorkingDirExist,
+		DebugPort:            c.String("debug-port"),
 	})
 	if err != nil {
 		log.Fatalf("Could not initiate %s runtime: %s\n", function.Runtime(), err)

--- a/invoke.go
+++ b/invoke.go
@@ -117,10 +117,10 @@ func invoke(c *cli.Context) {
 		funcEnvVarsOverrides = map[string]string{}
 	}
 
-        baseDir := c.String("docker-volume-basedir")
-        if baseDir == "" {
-            baseDir = filepath.Dir(filename)
-        }
+	baseDir := c.String("docker-volume-basedir")
+	if baseDir == "" {
+		baseDir = filepath.Dir(filename)
+	}
 
 	runt, err := NewRuntime(NewRuntimeOpt{
 		Function:         function,

--- a/main.go
+++ b/main.go
@@ -85,8 +85,9 @@ func main() {
 							EnvVar: "SAM_DEBUG_PORT",
 						},
                                                 cli.StringFlag{
-                                                        Name: "volume-basedir, v",
+                                                        Name: "docker-volume-basedir, v",
                                                         Usage: "Optional. Docker Volume Host Path",
+                                                        EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
                                                 },
 					},
 				},
@@ -122,8 +123,9 @@ func main() {
 							EnvVar: "SAM_DEBUG_PORT",
 						},
                                                 cli.StringFlag{
-                                                        Name: "volume-basedir, v",
+                                                        Name: "docker-volume-basedir, v",
                                                         Usage: "Optional. Docker Volume Host Path",
+                                                        EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
                                                 },
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -84,11 +84,11 @@ func main() {
 							Usage: "Optional. When specified, Lambda function container will start in debug mode and will expose this port on localhost.",
 							EnvVar: "SAM_DEBUG_PORT",
 						},
-                                                cli.StringFlag{
-                                                        Name: "docker-volume-basedir, v",
-                                                        Usage: "Optional. Docker Volume Host Path",
-                                                        EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
-                                                },
+						cli.StringFlag{
+							Name:   "docker-volume-basedir, v",
+							Usage:  "Optional. Docker Volume Host Path",
+							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
+						},
 					},
 				},
 				cli.Command{
@@ -122,11 +122,11 @@ func main() {
 							Usage: "Optional. When specified, Lambda function container will start in debug mode and will expose this port on localhost.",
 							EnvVar: "SAM_DEBUG_PORT",
 						},
-                                                cli.StringFlag{
-                                                        Name: "docker-volume-basedir, v",
-                                                        Usage: "Optional. Docker Volume Host Path",
-                                                        EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
-                                                },
+						cli.StringFlag{
+							Name:   "docker-volume-basedir, v",
+							Usage:  "Optional. Docker Volume Host Path",
+							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
+						},
 					},
 				},
 				cli.Command{

--- a/main.go
+++ b/main.go
@@ -85,8 +85,9 @@ func main() {
 							EnvVar: "SAM_DEBUG_PORT",
 						},
 						cli.StringFlag{
-							Name:   "docker-volume-basedir, v",
-							Usage:  "Optional. Docker Volume Host Path",
+							Name: "docker-volume-basedir, v",
+							Usage: "Optional. Specifies the location basedir where the SAM file exists. If the Docker is running on a remote machine, " +
+								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
 					},
@@ -123,8 +124,9 @@ func main() {
 							EnvVar: "SAM_DEBUG_PORT",
 						},
 						cli.StringFlag{
-							Name:   "docker-volume-basedir, v",
-							Usage:  "Optional. Docker Volume Host Path",
+							Name: "docker-volume-basedir, v",
+							Usage: "Optional. Specifies the location basedir where the SAM file exists. If the Docker is running on a remote machine, " +
+								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
 					},

--- a/main.go
+++ b/main.go
@@ -84,6 +84,10 @@ func main() {
 							Usage: "Optional. When specified, Lambda function container will start in debug mode and will expose this port on localhost.",
 							EnvVar: "SAM_DEBUG_PORT",
 						},
+                                                cli.StringFlag{
+                                                        Name: "volume-basedir, v",
+                                                        Usage: "Optional. Docker Volume Host Path",
+                                                },
 					},
 				},
 				cli.Command{
@@ -117,6 +121,10 @@ func main() {
 							Usage: "Optional. When specified, Lambda function container will start in debug mode and will expose this port on localhost.",
 							EnvVar: "SAM_DEBUG_PORT",
 						},
+                                                cli.StringFlag{
+                                                        Name: "volume-basedir, v",
+                                                        Usage: "Optional. Docker Volume Host Path",
+                                                },
 					},
 				},
 				cli.Command{

--- a/runtime.go
+++ b/runtime.go
@@ -573,13 +573,6 @@ func getWorkingDir(basedir string, codeuri string) (string, error) {
 
 	dir := filepath.Join(abs, codeuri)
 
-	// ...but only if it actually exists
-	if _, err := os.Stat(dir); err != nil {
-		// It doesn't, so just use the directory of the SAM template
-		// which might have been passed as a relative directory
-		dir = basedir
-	}
-
 	return dir, nil
 
 }

--- a/runtime.go
+++ b/runtime.go
@@ -573,8 +573,8 @@ func getWorkingDir(basedir string, codeuri string) (string, error) {
 
 	dir := filepath.Join(abs, codeuri)
 
-        // Windows uses \ as the path delimiter, but Docker requires / as the path delimiter.
-        dir = filepath.ToSlash(dir)
+	// Windows uses \ as the path delimiter, but Docker requires / as the path delimiter.
+	dir = filepath.ToSlash(dir)
 
 	return dir, nil
 

--- a/runtime.go
+++ b/runtime.go
@@ -573,6 +573,9 @@ func getWorkingDir(basedir string, codeuri string) (string, error) {
 
 	dir := filepath.Join(abs, codeuri)
 
+        // Windows uses \ as the path delimiter, but Docker requires / as the path delimiter.
+        dir = filepath.ToSlash(dir)
+
 	return dir, nil
 
 }

--- a/start.go
+++ b/start.go
@@ -83,10 +83,10 @@ func start(c *cli.Context) {
 
 	}
 
-        baseDir := c.String("docker-volume-basedir")
-        if baseDir == "" {
-            baseDir = filepath.Dir(filename)
-        }
+	baseDir := c.String("docker-volume-basedir")
+	if baseDir == "" {
+		baseDir = filepath.Dir(filename)
+	}
 
 	log.Printf("Successfully parsed %s (version %s)", filename, template.Version())
 

--- a/start.go
+++ b/start.go
@@ -84,8 +84,10 @@ func start(c *cli.Context) {
 	}
 
 	baseDir := c.String("docker-volume-basedir")
+	checkWorkingDirExist := false
 	if baseDir == "" {
 		baseDir = filepath.Dir(filename)
+		checkWorkingDirExist = true
 	}
 
 	log.Printf("Successfully parsed %s (version %s)", filename, template.Version())
@@ -118,10 +120,11 @@ func start(c *cli.Context) {
 				funcEnvVarsOverrides := envVarsOverrides[name]
 
 				runt, err := NewRuntime(NewRuntimeOpt{
-					Function:         function,
-					EnvVarsOverrides: funcEnvVarsOverrides,
-					Basedir:          baseDir,
-					DebugPort:        c.String("debug-port"),
+					Function:             function,
+					EnvVarsOverrides:     funcEnvVarsOverrides,
+					Basedir:              baseDir,
+					CheckWorkingDirExist: checkWorkingDirExist,
+					DebugPort:            c.String("debug-port"),
 				})
 				if err != nil {
 					if err == ErrRuntimeNotSupported {

--- a/start.go
+++ b/start.go
@@ -83,7 +83,7 @@ func start(c *cli.Context) {
 
 	}
 
-        baseDir := c.String("volume-basedir")
+        baseDir := c.String("docker-volume-basedir")
         if baseDir == "" {
             baseDir = filepath.Dir(filename)
         }

--- a/start.go
+++ b/start.go
@@ -83,6 +83,11 @@ func start(c *cli.Context) {
 
 	}
 
+        baseDir := c.String("volume-basedir")
+        if baseDir == "" {
+            baseDir = filepath.Dir(filename)
+        }
+
 	log.Printf("Successfully parsed %s (version %s)", filename, template.Version())
 
 	// Create a new HTTP router to mount the functions on
@@ -115,7 +120,7 @@ func start(c *cli.Context) {
 				runt, err := NewRuntime(NewRuntimeOpt{
 					Function:         function,
 					EnvVarsOverrides: funcEnvVarsOverrides,
-					Basedir:          filepath.Dir(filename),
+					Basedir:          baseDir,
 					DebugPort:        c.String("debug-port"),
 				})
 				if err != nil {


### PR DESCRIPTION
When using the Remote Docker, there is a problem that the function code can not be found.

Modified to allow the host path to the volume to be specified, assuming that the specific path of the development machine is mounted on the Docker Host. (Ex: Docker Toolbox)

```
sam local invoke "TestFunc" -v /c/Users/shlee/projects/test-project
```
