### PR TITLE
Set node_modules/.bin symlink

### DIFF
--- a/distribution/npm/package.json
+++ b/distribution/npm/package.json
@@ -7,7 +7,7 @@
     "go-npm": "^0.1.8"
   },
   "scripts": {
-    "postinstall": "go-npm install",
+    "postinstall": "go-npm install && ln -s ../aws-sam-local/node_modules/.bin/sam ../.bin/sam",
     "preuninstall": "go-npm uninstall"
   },
   "goBinary": {


### PR DESCRIPTION
Currently `aws-sam-local` does not create symlink into `<my-project-root>/node_modules/.bin` when the package is installed locally (i.e. without the -g flag).

Which means one has to explicitly provide local paths in `package.json` scripts:
```json
"scripts": {
    "start": "./node_modules/aws-sam-local/node_modules/.bin/sam local start-api"
}
```

Instead if the module would set its binary symlink properly, one could just use only binary name in `package.json` scripts:
```json
"scripts": {
    "start": "sam local start-api"
}
```

---


AFAIK setting [`bin`-object withing packege.json](https://docs.npmjs.com/files/package.json#bin) is the preferred method, but I personally couldn't get it to work with this `go-npm` setup. Therefore I used more "direct approach" and just [manually created the symlink on `postinstall`](https://github.com/aripalo/aws-sam-local/blob/ed0ed100458185e27b83143f6a3de9d0a3e44c44/distribution/npm/package.json#L10).

There probably is a more elegant solution, but at least this works.