### PR TITLE
New HTTP router implementation for 'sam local start-api'

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/awslabs/goformation/cloudformation"
+)
+
+/**
+ The Environment Variable Saga..
+
+ There are two types of environment variables
+ 	- Lambda runtime variables starting with "AWS_" and passed to every function
+ 	- Custom environment variables defined in SAM template for each function
+
+ Custom environment variables defined in the SAM template can contain hard-coded
+ values or fetch from a stack parameter or use Intrinsics to generate a value at
+ at stack creation time like ARNs. It can get complicated to support all cases
+
+ Instead we will parse only hard-coded values from the template. For the rest,
+ users can supply values through the Shell's environment or the env-var override
+ CLI argument. If a value is provided through more than one method, the method
+ with higher priority will win.
+
+ Priority (Highest to lowest)
+	Env-Var CLI argument
+	Shell's Environment
+	Hard-coded values from template
+
+ This priority also applies to AWS_* system variables
+*/
+
+func getEnvironmentVariables(logicalID string, function *cloudformation.AWSServerlessFunction, overrideFile string) map[string]string {
+
+	env := getEnvDefaults(function)
+	osenv := getEnvFromOS()
+	overrides := getEnvOverrides(logicalID, overrideFile)
+
+	for name, value := range function.Environment.Variables {
+
+		// hard-coded values, lowest priority
+		if stringedValue, ok := toStringMaybe(value); ok {
+			// Get only hard-coded values from the template
+			env[name] = stringedValue
+		}
+
+		// Shell's environment, second priority
+		if value, ok := osenv[name]; ok {
+			env[name] = value
+		}
+
+		// EnvVars overrides provided by customer, highest priority
+		if len(overrides) > 0 {
+			if value, ok := overrides[name]; ok {
+				env[name] = value
+			}
+		}
+	}
+
+	return env
+
+}
+
+func getEnvDefaults(function *cloudformation.AWSServerlessFunction) map[string]string {
+
+	creds := getSessionOrDefaultCreds()
+
+	// Variables available in Lambda execution environment for all functions (AWS_* variables)
+	return map[string]string{
+		"AWS_SAM_LOCAL":                   "true",
+		"AWS_REGION":                      creds["region"],
+		"AWS_DEFAULT_REGION":              creds["region"],
+		"AWS_ACCESS_KEY_ID":               creds["key"],
+		"AWS_SECRET_ACCESS_KEY":           creds["secret"],
+		"AWS_SESSION_TOKEN":               creds["sessiontoken"],
+		"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": strconv.Itoa(int(function.MemorySize)),
+		"AWS_LAMBDA_FUNCTION_TIMEOUT":     strconv.Itoa(int(function.Timeout)),
+		"AWS_LAMBDA_FUNCTION_HANDLER":     function.Handler,
+		// "AWS_ACCOUNT_ID=",
+		// "AWS_LAMBDA_EVENT_BODY=",
+		// "AWS_REGION=",
+		// "AWS_LAMBDA_FUNCTION_NAME=",
+		// "AWS_LAMBDA_FUNCTION_VERSION=",
+	}
+
+}
+
+func getEnvOverrides(logicalID string, filename string) map[string]string {
+
+	if len(filename) > 0 {
+
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			log.Printf("Could not read environment overrides from %s: %s\n", filename, err)
+			return map[string]string{}
+		}
+
+		// This is a JSON of structure {FunctionName: {key:value}, FunctionName: {key:value}}
+		overrides := map[string]map[string]string{}
+		if err = json.Unmarshal(data, &overrides); err != nil {
+			log.Printf("Invalid environment override file %s: %s\n", filename, err)
+			return map[string]string{}
+		}
+
+		return overrides[logicalID]
+
+	}
+
+	return map[string]string{}
+
+}
+
+func getSessionOrDefaultCreds() map[string]string {
+
+	region := "us-east-1"
+	key := "defaultkey"
+	secret := "defaultsecret"
+	sessiontoken := "sessiontoken"
+
+	result := map[string]string{
+		"region":  region,
+		"key":     key,
+		"secret":  secret,
+		"session": sessiontoken,
+	}
+
+	// Obtain AWS credentials and pass them through to the container runtime via env variables
+	if sess, err := session.NewSession(); err == nil {
+		if creds, err := sess.Config.Credentials.Get(); err == nil {
+			if *sess.Config.Region != "" {
+				result["region"] = *sess.Config.Region
+			}
+
+			result["key"] = creds.AccessKeyID
+			result["secret"] = creds.SecretAccessKey
+			result["sessiontoken"] = creds.SessionToken
+		}
+	}
+	return result
+}
+
+func getEnvFromOS() map[string]string {
+
+	result := map[string]string{}
+	for _, value := range os.Environ() {
+		keyVal := strings.Split(value, "=")
+		result[keyVal[0]] = keyVal[1]
+	}
+
+	return result
+}
+
+// Converts the input to string if it is a primitive type, Otherwise returns nil
+func toStringMaybe(value interface{}) (string, bool) {
+
+	switch value.(type) {
+	case string:
+		return value.(string), true
+	case int:
+		return strconv.Itoa(value.(int)), true
+	case float32, float64:
+		return strconv.FormatFloat(value.(float64), 'f', -1, 64), true
+	case bool:
+		return strconv.FormatBool(value.(bool)), true
+	default:
+		return "", false
+	}
+
+}

--- a/env.go
+++ b/env.go
@@ -42,23 +42,25 @@ func getEnvironmentVariables(logicalID string, function *cloudformation.AWSServe
 	osenv := getEnvFromOS()
 	overrides := getEnvOverrides(logicalID, overrideFile)
 
-	for name, value := range function.Environment.Variables {
+	if function.Environment != nil {
+		for name, value := range function.Environment.Variables {
 
-		// hard-coded values, lowest priority
-		if stringedValue, ok := toStringMaybe(value); ok {
-			// Get only hard-coded values from the template
-			env[name] = stringedValue
-		}
+			// hard-coded values, lowest priority
+			if stringedValue, ok := toStringMaybe(value); ok {
+				// Get only hard-coded values from the template
+				env[name] = stringedValue
+			}
 
-		// Shell's environment, second priority
-		if value, ok := osenv[name]; ok {
-			env[name] = value
-		}
-
-		// EnvVars overrides provided by customer, highest priority
-		if len(overrides) > 0 {
-			if value, ok := overrides[name]; ok {
+			// Shell's environment, second priority
+			if value, ok := osenv[name]; ok {
 				env[name] = value
+			}
+
+			// EnvVars overrides provided by customer, highest priority
+			if len(overrides) > 0 {
+				if value, ok := overrides[name]; ok {
+					env[name] = value
+				}
 			}
 		}
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+
+	"github.com/awslabs/goformation"
+	"github.com/awslabs/goformation/cloudformation"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Environment Variables", func() {
+
+	Context("with a template that has environment variables defined", func() {
+
+		var functions map[string]cloudformation.AWSServerlessFunction
+		BeforeEach(func() {
+			template, _ := goformation.Open("test/templates/sam-official-samples/iot_backend/template.yaml")
+			functions = template.GetAllAWSServerlessFunctionResources()
+		})
+
+		It("return defaults with those defined in the template", func() {
+
+			for name, function := range functions {
+				variables := getEnvironmentVariables(name, &function, "")
+				Expect(variables).To(HaveLen(10))
+				Expect(variables).To(HaveKey("AWS_SAM_LOCAL"))
+				Expect(variables).To(HaveKey("AWS_REGION"))
+				Expect(variables).To(HaveKey("AWS_DEFAULT_REGION"))
+				Expect(variables).To(HaveKey("AWS_ACCESS_KEY_ID"))
+				Expect(variables).To(HaveKey("AWS_SECRET_ACCESS_KEY"))
+				Expect(variables).To(HaveKey("AWS_SESSION_TOKEN"))
+				Expect(variables).To(HaveKey("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"))
+				Expect(variables).To(HaveKey("AWS_LAMBDA_FUNCTION_TIMEOUT"))
+				Expect(variables).To(HaveKey("AWS_LAMBDA_FUNCTION_HANDLER"))
+				Expect(variables).To(HaveKey("TABLE_NAME"))
+			}
+		})
+
+		It("overides template with environment variables", func() {
+			for name, function := range functions {
+				variables := getEnvironmentVariables(name, &function, "")
+				Expect(variables["TABLE_NAME"]).To(Equal(""))
+
+				os.Setenv("TABLE_NAME", "ENV_TABLE")
+				variables = getEnvironmentVariables(name, &function, "")
+				Expect(variables["TABLE_NAME"]).To(Equal("ENV_TABLE"))
+				os.Unsetenv("TABLE_NAME")
+			}
+		})
+
+		It("overrides template and environment with customer overrides", func() {
+			for name, function := range functions {
+				variables := getEnvironmentVariables(name, &function, "test/environment-overrides.json")
+				Expect(variables["TABLE_NAME"]).To(Equal("OVERRIDE_TABLE"))
+			}
+			os.Unsetenv("TABLE_NAME")
+		})
+
+	})
+})

--- a/invoke.go
+++ b/invoke.go
@@ -93,6 +93,7 @@ func invoke(c *cli.Context) {
 		DebugPort:       c.String("debug-port"),
 		SkipPullImage:   c.Bool("skip-pull-image"),
 	})
+
 	if err != nil {
 		log.Fatalf("Could not initiate %s runtime: %s\n", function.Runtime, err)
 	}

--- a/invoke.go
+++ b/invoke.go
@@ -79,21 +79,18 @@ func invoke(c *cli.Context) {
 
 	log.Printf("Connected to Docker %s", dockerVersion)
 
-	baseDir := c.String("docker-volume-basedir")
-	checkWorkingDirExist := false
-	if baseDir == "" {
-		baseDir = filepath.Dir(filename)
-		checkWorkingDirExist = true
+	cwd := filepath.Dir(filename)
+	if c.String("docker-volume-basedir") != "" {
+		cwd = c.String("docker-volume-basedir")
 	}
 
 	runt, err := NewRuntime(NewRuntimeOpt{
-		LogicalID:            name,
-		Function:             function,
-		Logger:               stderr,
-		EnvOverrideFile:      c.String("env-vars"),
-		Basedir:              baseDir,
-		CheckWorkingDirExist: checkWorkingDirExist,
-		DebugPort:            c.String("debug-port"),
+		Cwd:             cwd,
+		LogicalID:       name,
+		Function:        function,
+		Logger:          stderr,
+		EnvOverrideFile: c.String("env-vars"),
+		DebugPort:       c.String("debug-port"),
 	})
 	if err != nil {
 		log.Fatalf("Could not initiate %s runtime: %s\n", function.Runtime, err)

--- a/invoke.go
+++ b/invoke.go
@@ -91,6 +91,7 @@ func invoke(c *cli.Context) {
 		Logger:          stderr,
 		EnvOverrideFile: c.String("env-vars"),
 		DebugPort:       c.String("debug-port"),
+		SkipPullImage:   c.Bool("skip-pull-image"),
 	})
 	if err != nil {
 		log.Fatalf("Could not initiate %s runtime: %s\n", function.Runtime, err)

--- a/main.go
+++ b/main.go
@@ -96,13 +96,12 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
-						cli.BoolFlag {
-							Name: "skip-pull-image, p",
-							Usage: "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
+						cli.BoolFlag{
+							Name:   "skip-pull-image",
+							Usage:  "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
 							EnvVar: "SAM_SKIP_PULL_IMAGE",
 						},
-	
-				},
+					},
 				},
 				cli.Command{
 					Name:   "invoke",
@@ -141,12 +140,11 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
-						cli.BoolFlag {
-							Name: "skip-pull-image, p",
-							Usage: "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
+						cli.BoolFlag{
+							Name:   "skip-pull-image",
+							Usage:  "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
 							EnvVar: "SAM_SKIP_PULL_IMAGE",
 						},
-	
 					},
 				},
 				cli.Command{

--- a/main.go
+++ b/main.go
@@ -96,7 +96,13 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
-					},
+						cli.BoolFlag {
+							Name: "skip-pull-image, p",
+							Usage: "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
+							EnvVar: "SAM_SKIP_PULL_IMAGE",
+						},
+	
+				},
 				},
 				cli.Command{
 					Name:   "invoke",
@@ -135,6 +141,12 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
+						cli.BoolFlag {
+							Name: "skip-pull-image, p",
+							Usage: "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
+							EnvVar: "SAM_SKIP_PULL_IMAGE",
+						},
+	
 					},
 				},
 				cli.Command{

--- a/router/api.go
+++ b/router/api.go
@@ -1,0 +1,75 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/awslabs/goformation/cloudformation"
+)
+
+// AWSServerlessApi wraps GoFormation's AWS::Serverless::Api definition
+// and adds some convenience methods for extracting the ServerlessRouterMount's
+// from the swagger defintion etc.
+type AWSServerlessApi struct {
+	*cloudformation.AWSServerlessApi
+}
+
+// Mounts fetches an array of the ServerlessRouterMount's for this API.
+// These contain the path, method and handler function for each mount point.
+func (api *AWSServerlessApi) Mounts() ([]*ServerlessRouterMount, error) {
+	return nil, nil
+}
+
+// Swagger gets the swagger definition for the API.
+// Returns the swagger definition as a []byte of JSON.
+func (api *AWSServerlessApi) Swagger() ([]byte, error) {
+
+	// The swagger definition can be passed in 1 of 4 ways:
+
+	// 1. A definition URI defined as a string
+	if api.DefinitionUri != nil {
+		if api.DefinitionUri.String != nil {
+			return api.getSwaggerFromURI(*api.DefinitionUri.String)
+		}
+	}
+
+	// 2. A definition URI defined as an S3 Location
+	if api.DefinitionUri != nil {
+		if api.DefinitionUri.S3Location != nil {
+			return api.getSwaggerFromS3Location(*api.DefinitionUri.S3Location)
+		}
+	}
+
+	if api.DefinitionBody != nil {
+
+		switch val := api.DefinitionBody.(type) {
+
+		case string:
+			// 3. A definition body defined as JSON (which will unmarshal to a string)
+			return api.getSwaggerFromString(val)
+
+		case map[string]interface{}:
+			// 4. A definition body defined as YAML (which will unmarshal to map[string]interface{})
+			return api.getSwaggerFromMap(val)
+		}
+
+	}
+
+	return nil, fmt.Errorf("no swagger definition found")
+
+}
+
+func (api *AWSServerlessApi) getSwaggerFromURI(uri string) ([]byte, error) {
+	return nil, nil
+}
+
+func (api *AWSServerlessApi) getSwaggerFromS3Location(cloudformation.AWSServerlessApi_S3Location) ([]byte, error) {
+	return nil, nil
+}
+
+func (api *AWSServerlessApi) getSwaggerFromString(input string) ([]byte, error) {
+	return nil, nil
+}
+
+func (api *AWSServerlessApi) getSwaggerFromMap(input map[string]interface{}) ([]byte, error) {
+	return nil, nil
+}

--- a/router/function.go
+++ b/router/function.go
@@ -1,0 +1,39 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/awslabs/goformation/cloudformation"
+)
+
+// AWSServerlessFunction wraps GoFormation's AWS::Serverless::Function definition
+// and adds some convenience methods for extracting the ServerlessRouterMount's
+// from the event sources.
+type AWSServerlessFunction struct {
+	*cloudformation.AWSServerlessFunction
+	handler http.HandlerFunc
+}
+
+// Mounts fetches an array of the ServerlessRouterMount's for this API.
+// These contain the path, method and handler function for each mount point.
+func (f *AWSServerlessFunction) Mounts() ([]*ServerlessRouterMount, error) {
+
+	mounts := []*ServerlessRouterMount{}
+
+	for name, event := range f.Events {
+		if event.Type == "Api" {
+			if event.Properties != nil && event.Properties.ApiEvent != nil {
+				mounts = append(mounts, &ServerlessRouterMount{
+					Name:     name,
+					Path:     event.Properties.ApiEvent.Path,
+					Method:   event.Properties.ApiEvent.Method,
+					Handler:  f.handler,
+					Function: f,
+				})
+			}
+		}
+	}
+
+	return mounts, nil
+
+}

--- a/router/function_test.go
+++ b/router/function_test.go
@@ -1,0 +1,136 @@
+package router_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/awslabs/aws-sam-local/router"
+	"github.com/awslabs/goformation/cloudformation"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("Function", func() {
+
+	Context("with a GoFormation AWS::Serverless::Function", func() {
+
+		r := router.NewServerlessRouter()
+
+		function := &cloudformation.AWSServerlessFunction{
+			Runtime: "nodejs6.10",
+			Events: map[string]cloudformation.AWSServerlessFunction_EventSource{
+				"GetRequests": cloudformation.AWSServerlessFunction_EventSource{
+					Type: "Api",
+					Properties: &cloudformation.AWSServerlessFunction_S3EventOrSNSEventOrKinesisEventOrDynamoDBEventOrApiEventOrScheduleEventOrCloudWatchEventEventOrIoTRuleEventOrAlexaSkillEvent{
+						ApiEvent: &cloudformation.AWSServerlessFunction_ApiEvent{
+							Path:   "/get",
+							Method: "get",
+						},
+					},
+				},
+				"PostRequests": cloudformation.AWSServerlessFunction_EventSource{
+					Type: "Api",
+					Properties: &cloudformation.AWSServerlessFunction_S3EventOrSNSEventOrKinesisEventOrDynamoDBEventOrApiEventOrScheduleEventOrCloudWatchEventEventOrIoTRuleEventOrAlexaSkillEvent{
+						ApiEvent: &cloudformation.AWSServerlessFunction_ApiEvent{
+							Path:   "/post",
+							Method: "post",
+						},
+					},
+				},
+				"AnyRequests": cloudformation.AWSServerlessFunction_EventSource{
+					Type: "Api",
+					Properties: &cloudformation.AWSServerlessFunction_S3EventOrSNSEventOrKinesisEventOrDynamoDBEventOrApiEventOrScheduleEventOrCloudWatchEventEventOrIoTRuleEventOrAlexaSkillEvent{
+						ApiEvent: &cloudformation.AWSServerlessFunction_ApiEvent{
+							Path:   "/any",
+							Method: "any",
+						},
+					},
+				},
+			},
+		}
+
+		err := r.AddFunction(function, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("ok"))
+		})
+
+		It("should add the function successfully", func() {
+			Expect(err).To(BeNil())
+		})
+
+		mounts := r.Mounts()
+		It("should find three API event sources", func() {
+			Expect(mounts).To(HaveLen(3))
+		})
+
+		It("should have the correct values for an event with GET http method", func() {
+			Expect(mounts).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Name":   Equal("GetRequests"),
+				"Path":   Equal("/get"),
+				"Method": Equal("get"),
+			}))))
+		})
+
+		It("should have the correct values for an event with POST http method", func() {
+			Expect(mounts).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Name":   Equal("PostRequests"),
+				"Path":   Equal("/post"),
+				"Method": Equal("post"),
+			}))))
+		})
+
+		It("should have the correct values for an event with ANY http method", func() {
+			Expect(mounts).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Name":   Equal("AnyRequests"),
+				"Path":   Equal("/any"),
+				"Method": Equal("any"),
+			}))))
+		})
+
+		It("should respond to HTTP requests on GET /get", func() {
+			req, _ := http.NewRequest("GET", "/get", nil)
+			rr := httptest.NewRecorder()
+			r.Router().ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(rr.Body.String()).To(Equal("ok"))
+		})
+
+		It("should respond to HTTP requests on POST /post", func() {
+			req, _ := http.NewRequest("POST", "/post", nil)
+			rr := httptest.NewRecorder()
+			r.Router().ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(rr.Body.String()).To(Equal("ok"))
+		})
+
+		It("should respond to HTTP requests on POST /post", func() {
+			req, _ := http.NewRequest("POST", "/post", nil)
+			rr := httptest.NewRecorder()
+			r.Router().ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(rr.Body.String()).To(Equal("ok"))
+		})
+
+		It("should respond with a 404 to HTTP requests on an invalid path", func() {
+			req, _ := http.NewRequest("GET", "/invalid", nil)
+			rr := httptest.NewRecorder()
+			r.Router().ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusNotFound))
+		})
+
+		methods := []string{"OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"}
+		for _, method := range methods {
+			It("should respond to HTTP requests on "+method+" /any", func() {
+				req, _ := http.NewRequest(method, "/any", nil)
+				rr := httptest.NewRecorder()
+				r.Router().ServeHTTP(rr, req)
+				Expect(rr.Code).To(Equal(http.StatusOK))
+				Expect(rr.Body.String()).To(Equal("ok"))
+			})
+		}
+
+	})
+
+})

--- a/router/function_test.go
+++ b/router/function_test.go
@@ -133,4 +133,23 @@ var _ = Describe("Function", func() {
 
 	})
 
+	Context("with a GoFormation AWS::Serverless::Function that has no 'Api' event sources", func() {
+
+		r := router.NewServerlessRouter()
+
+		function := &cloudformation.AWSServerlessFunction{
+			Runtime: "nodejs6.10",
+		}
+
+		err := r.AddFunction(function, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("ok"))
+		})
+
+		It("should throw a ErrNoEventsFound error", func() {
+			Expect(err).To(MatchError(router.ErrNoEventsFound))
+		})
+
+	})
+
 })

--- a/router/mount.go
+++ b/router/mount.go
@@ -1,0 +1,27 @@
+package router
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ServerlessRouterMount represents a single mount point on the API
+// Such as '/path', the HTTP method, and the function to resolve it
+type ServerlessRouterMount struct {
+	Name     string
+	Function *AWSServerlessFunction
+	Handler  http.HandlerFunc
+	Path     string
+	Method   string
+}
+
+// Methods gets an array of HTTP methods from a AWS::Serverless::Function
+// API event source method declaration (which could include 'any')
+func (m *ServerlessRouterMount) Methods() []string {
+	switch strings.ToUpper(m.Method) {
+	case "ANY":
+		return []string{"OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"}
+	default:
+		return []string{strings.ToUpper(m.Method)}
+	}
+}

--- a/router/mount_test.go
+++ b/router/mount_test.go
@@ -1,0 +1,64 @@
+package router_test
+
+import (
+	. "github.com/awslabs/aws-sam-local/router"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServerlessRouterMount", func() {
+
+	Context("with a method in uppercase", func() {
+
+		m := ServerlessRouterMount{
+			Path:   "/test",
+			Method: "GET",
+		}
+
+		methods := m.Methods()
+		It("should have the correct HTTP method", func() {
+			Expect(methods).To(HaveLen(1))
+			Expect(methods).To(ContainElement("GET"))
+		})
+
+	})
+
+	Context("with a method in lowercase", func() {
+
+		m := ServerlessRouterMount{
+			Path:   "/test",
+			Method: "get",
+		}
+
+		methods := m.Methods()
+		It("should have the correct HTTP method", func() {
+			Expect(methods).To(HaveLen(1))
+			Expect(methods).To(ContainElement("GET"))
+		})
+
+	})
+
+	Context("with method 'any'", func() {
+
+		m := ServerlessRouterMount{
+			Path:   "/test",
+			Method: "any",
+		}
+
+		methods := m.Methods()
+		It("should have the correct HTTP method", func() {
+			Expect(methods).To(HaveLen(8))
+			Expect(methods).To(ContainElement("OPTIONS"))
+			Expect(methods).To(ContainElement("GET"))
+			Expect(methods).To(ContainElement("HEAD"))
+			Expect(methods).To(ContainElement("POST"))
+			Expect(methods).To(ContainElement("PUT"))
+			Expect(methods).To(ContainElement("DELETE"))
+			Expect(methods).To(ContainElement("TRACE"))
+			Expect(methods).To(ContainElement("CONNECT"))
+		})
+
+	})
+
+})

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,87 @@
+package router
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/awslabs/goformation/cloudformation"
+	"github.com/gorilla/mux"
+)
+
+// ErrNoEventsFound is thrown if a AWS::Serverless::Function is added to this
+// router, but no API event sources exist for it.
+var ErrNoEventsFound = errors.New("no events with type 'Api' were found")
+
+// ServerlessRouter takes AWS::Serverless::Function and AWS::Serverless::API objects
+// and creates a Go http.Handler with the correct paths/methods mounted
+type ServerlessRouter struct {
+	mux    *mux.Router
+	mounts []*ServerlessRouterMount
+}
+
+// NewServerlessRouter creates a new instance of ServerlessRouter
+func NewServerlessRouter() *ServerlessRouter {
+	return &ServerlessRouter{
+		mux:    mux.NewRouter(),
+		mounts: []*ServerlessRouterMount{},
+	}
+}
+
+// AddFunction adds a AWS::Serverless::Function to the router and mounts all of it's
+// event sources that have type 'Api'
+func (r *ServerlessRouter) AddFunction(f *cloudformation.AWSServerlessFunction, handler http.HandlerFunc) error {
+
+	// Wrap GoFormation's AWS::Serverless::Function definition in our own, which provides
+	// convenience methods for extracting the ServerlessRouterMount(s) from it.
+	function := &AWSServerlessFunction{f, handler}
+	mounts, err := function.Mounts()
+	if err != nil {
+		return err
+	}
+
+	if len(mounts) < 1 {
+		return ErrNoEventsFound
+	}
+
+	r.mounts = append(r.mounts, mounts...)
+	return nil
+
+}
+
+// AddAPI adds a AWS::Serverless::Api resource to the router, and mounts all of it's API definition
+func (r *ServerlessRouter) AddAPI(a *cloudformation.AWSServerlessApi) error {
+
+	// Wrap GoFormation's AWS::Serverless::Api definition in our own, which provides
+	// convenience methods for extracting the ServerlessRouterMount(s) from it.
+	api := &AWSServerlessApi{a}
+	mounts, err := api.Mounts()
+	if err != nil {
+		return err
+	}
+
+	r.mounts = append(r.mounts, mounts...)
+	return nil
+
+}
+
+// AddStaticDir mounts a static directory provided, at the mount point also provided
+func (r *ServerlessRouter) AddStaticDir(dirname string, mountpoint string) {
+	r.mux.PathPrefix(mountpoint).Handler(http.FileServer(http.Dir(dirname)))
+}
+
+// Router returns the Go http.Handler for the router, to be passed to http.ListenAndServe()
+func (r *ServerlessRouter) Router() http.Handler {
+
+	// Mount all of the things!
+	for _, mount := range r.Mounts() {
+		r.mux.Handle(mount.Path, mount.Handler).Methods(mount.Methods()...)
+	}
+
+	return r.mux
+
+}
+
+// Mounts returns a list of the mounts associated with this router
+func (r *ServerlessRouter) Mounts() []*ServerlessRouterMount {
+	return r.mounts
+}

--- a/router/router.go
+++ b/router/router.go
@@ -65,8 +65,8 @@ func (r *ServerlessRouter) AddAPI(a *cloudformation.AWSServerlessApi) error {
 }
 
 // AddStaticDir mounts a static directory provided, at the mount point also provided
-func (r *ServerlessRouter) AddStaticDir(dirname string, mountpoint string) {
-	r.mux.PathPrefix(mountpoint).Handler(http.FileServer(http.Dir(dirname)))
+func (r *ServerlessRouter) AddStaticDir(dirname string) {
+	r.mux.NotFoundHandler = http.FileServer(http.Dir(dirname))
 }
 
 // Router returns the Go http.Handler for the router, to be passed to http.ListenAndServe()

--- a/router/router_suite_test.go
+++ b/router/router_suite_test.go
@@ -1,0 +1,13 @@
+package router_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRouter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Router Suite")
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,0 +1,9 @@
+package router_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("ServerlessRouter", func() {
+
+})

--- a/runtime.go
+++ b/runtime.go
@@ -582,7 +582,7 @@ func getDockerVersion() (string, error) {
 func getWorkingDir(dir string) string {
 
 	// If the template filepath isn't set, just use the cwd
-	if dir == "" {
+	if dir == "" || dir == "." {
 		cwd, err := os.Getwd()
 		if err != nil {
 			// A directory wasn't specified on the command line

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -23,6 +23,7 @@ var _ = Describe("sam", func() {
 			inputs := [][]string{
 				// input path, output path
 				[]string{"", cwd},
+				[]string{".", cwd},
 				[]string{"/test/directory", "/test/directory"},
 				[]string{"test/directory", "test/directory"},
 			}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/awslabs/goformation"
-	"github.com/awslabs/goformation/cloudformation"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -77,59 +75,6 @@ var _ = Describe("sam", func() {
 				})
 
 			}
-
-		})
-
-		Context("environment variables", func() {
-
-			var functions map[string]cloudformation.AWSServerlessFunction
-			BeforeEach(func() {
-				template, _ := goformation.Open("test/templates/sam-official-samples/iot_backend/template.yaml")
-				functions = template.GetAllAWSServerlessFunctionResources()
-			})
-
-			It("return defaults with those defined in the template", func() {
-
-				for _, function := range functions {
-					variables := getEnvironmentVariables(function, map[string]string{})
-					Expect(variables).To(HaveLen(10))
-					Expect(variables).To(HaveKey("AWS_SAM_LOCAL"))
-					Expect(variables).To(HaveKey("AWS_REGION"))
-					Expect(variables).To(HaveKey("AWS_DEFAULT_REGION"))
-					Expect(variables).To(HaveKey("AWS_ACCESS_KEY_ID"))
-					Expect(variables).To(HaveKey("AWS_SECRET_ACCESS_KEY"))
-					Expect(variables).To(HaveKey("AWS_SESSION_TOKEN"))
-					Expect(variables).To(HaveKey("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"))
-					Expect(variables).To(HaveKey("AWS_LAMBDA_FUNCTION_TIMEOUT"))
-					Expect(variables).To(HaveKey("AWS_LAMBDA_FUNCTION_HANDLER"))
-					Expect(variables).To(HaveKey("TABLE_NAME"))
-				}
-			})
-
-			It("overides template with environment variables", func() {
-				for _, function := range functions {
-					variables := getEnvironmentVariables(function, map[string]string{})
-					Expect(variables["TABLE_NAME"]).To(Equal(""))
-
-					os.Setenv("TABLE_NAME", "ENV_TABLE")
-					variables = getEnvironmentVariables(function, map[string]string{})
-					Expect(variables["TABLE_NAME"]).To(Equal("ENV_TABLE"))
-					os.Unsetenv("TABLE_NAME")
-				}
-			})
-
-			It("overrides template and environment with customer overrides", func() {
-				os.Setenv("TABLE_NAME", "ENV_TABLE")
-				overrides := map[string]string{
-					"TABLE_NAME": "OVERRIDE_TABLE",
-				}
-
-				for _, function := range functions {
-					variables := getEnvironmentVariables(function, overrides)
-					Expect(variables["TABLE_NAME"]).To(Equal("OVERRIDE_TABLE"))
-				}
-				os.Unsetenv("TABLE_NAME")
-			})
 
 		})
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3,9 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,53 +20,23 @@ var _ = Describe("sam", func() {
 				Expect(err).To(BeNil())
 			})
 
-			baseDir := "/" + strings.Trim(os.TempDir(), "/")
-			baseDirNonExistent := "/yeHNpGawFr0SJ9RZae6mWJKrqvfjaNbJgOM3oQhAQQif6e1Dpbra"
-			baseDirEmpty := ""
-
-			codeUri := "./test"
-			codeUriUnknown := "s3://<bucket>/packaged.zip"
-			codeUriEmpty := ""
-			os.Mkdir(filepath.Join(baseDir, codeUri), 0755)
-
 			inputs := [][]string{
-				// basedir, CodeUri, checkWorkingDir, expected result
-				[]string{baseDir, codeUri, "true", filepath.Join(baseDir, codeUri)},
-				[]string{baseDirNonExistent, codeUri, "true", baseDirNonExistent},
-				[]string{baseDirEmpty, codeUri, "true", filepath.Join(cwd, codeUri)},
-				[]string{baseDir, codeUriUnknown, "true", baseDir},
-				[]string{baseDirNonExistent, codeUriUnknown, "true", baseDirNonExistent},
-				[]string{baseDirEmpty, codeUriUnknown, "true", cwd},
-				[]string{baseDir, codeUriEmpty, "true", baseDir},
-				[]string{baseDirNonExistent, codeUriEmpty, "true", baseDirNonExistent},
-				[]string{baseDirEmpty, codeUriEmpty, "true", cwd},
-
-				// getWorkingDir=false is used when SAM Local runs locally, but the Docker container
-				// is on a remote host. The base path / CodeUri might not resolve locally.
-				[]string{baseDir, codeUri, "false", filepath.Join(baseDir, codeUri)},
-				[]string{baseDirNonExistent, codeUri, "false", filepath.Join(baseDirNonExistent, codeUri)},
-				[]string{baseDirEmpty, codeUri, "false", filepath.Join(cwd, codeUri)},
-				[]string{baseDir, codeUriUnknown, "false", filepath.Join(baseDir, codeUriUnknown)},
-				[]string{baseDirNonExistent, codeUriUnknown, "false", filepath.Join(baseDirNonExistent, codeUriUnknown)},
-				[]string{baseDirEmpty, codeUriUnknown, "false", filepath.Join(cwd, codeUriUnknown)},
-				[]string{baseDir, codeUriEmpty, "false", baseDir},
-				[]string{baseDirNonExistent, codeUriEmpty, "false", baseDirNonExistent},
-				[]string{baseDirEmpty, codeUriEmpty, "false", cwd},
+				// input path, output path
+				[]string{"", cwd},
+				[]string{"/test/directory", "/test/directory"},
+				[]string{"test/directory", "test/directory"},
 			}
 
 			// func getWorkingDir(basedir string, codeuri string, checkWorkingDirExist bool) (string, error) {
 			for _, input := range inputs {
 
-				basedir := input[0]
-				codeuri := input[1]
-				check, _ := strconv.ParseBool(input[2])
-				expected := input[3]
+				in := input[0]
+				expected := input[1]
 
-				context := fmt.Sprintf("with basedir=%s, CodeUri=%s and checkWorkingDirExists=%t", basedir, codeuri, check)
+				context := fmt.Sprintf("with input %s", in)
 				Context(context, func() {
 					It("should have the correct directory", func() {
-						dir, err := getWorkingDir(basedir, codeuri, check)
-						Expect(err).To(BeNil())
+						dir := getWorkingDir(in)
 						Expect(dir).To(Equal(expected))
 					})
 				})

--- a/samples/java/template.yml
+++ b/samples/java/template.yml
@@ -22,7 +22,7 @@ Resources:
         GetEvent:
           Type: Api
           Properties:
-            Path: /
+            Path: /java
             Method: get
 
   PostHelloWorld:

--- a/start.go
+++ b/start.go
@@ -66,6 +66,7 @@ func start(c *cli.Context) {
 			Logger:          stderr,
 			EnvOverrideFile: c.String("env-vars"),
 			DebugPort:       c.String("debug-port"),
+			SkipPullImage:   c.Bool("skip-pull-image"),
 		})
 
 		// Check there wasn't a problem initiating the Lambda runtime

--- a/start.go
+++ b/start.go
@@ -43,17 +43,20 @@ func start(c *cli.Context) {
 	}
 	log.Printf("Connected to Docker %s", dockerVersion)
 
+	// Get the working directory for the project based on
+	// the template directory. Also, give an opportunity for
+	// this to be overriden by the --docker-volume-basedir flag.
+	cwd := filepath.Dir(filename)
+	if c.String("docker-volume-basedir") != "" {
+		cwd = c.String("docker-volume-basedir")
+	}
+
 	// Create a new router
 	mux := router.NewServerlessRouter()
 
 	functions := template.GetAllAWSServerlessFunctionResources()
 
 	for name, function := range functions {
-
-		cwd := filepath.Dir(filename)
-		if c.String("docker-volume-basedir") != "" {
-			cwd = c.String("docker-volume-basedir")
-		}
 
 		// Initiate a new Lambda runtime
 		runt, err := NewRuntime(NewRuntimeOpt{
@@ -104,7 +107,7 @@ func start(c *cli.Context) {
 
 	// Mount static files
 	if c.String("static-dir") != "" {
-		static := filepath.Join(getWorkingDir(filename), c.String("static-dir"))
+		static := filepath.Join(cwd, c.String("static-dir"))
 		fmt.Fprintf(os.Stderr, "Mounting static files from %s at /\n", static)
 		mux.AddStaticDir(static)
 	}

--- a/start.go
+++ b/start.go
@@ -1,31 +1,17 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 
+	"github.com/awslabs/aws-sam-local/router"
 	"github.com/awslabs/goformation"
-	"github.com/awslabs/goformation/cloudformation"
-
 	"github.com/codegangsta/cli"
-	"github.com/fatih/color"
-	"github.com/gorilla/mux"
 )
-
-type mount struct {
-	Handler  string
-	Runtime  string
-	Endpoint string
-	Methods  []string
-}
 
 func start(c *cli.Context) {
 
@@ -55,33 +41,9 @@ func start(c *cli.Context) {
 		log.Printf("%s\n", err)
 		os.Exit(1)
 	}
-
 	log.Printf("Connected to Docker %s", dockerVersion)
 
-	envVarsFile := c.String("env-vars")
-	envVarsOverrides := map[string]map[string]string{}
-	if len(envVarsFile) > 0 {
-
-		f, err := os.Open(c.String("env-vars"))
-		if err != nil {
-			fmt.Printf("Failed to open environment variables values file\n%s\n", err)
-			os.Exit(1)
-		}
-
-		data, err := ioutil.ReadAll(f)
-		if err != nil {
-			fmt.Printf("Unable to read the environment variable values file\n%s\n", err)
-			os.Exit(1)
-		}
-
-		// This is a JSON of structure {FunctionName: {key:value}, FunctionName: {key:value}}
-		if err = json.Unmarshal(data, &envVarsOverrides); err != nil {
-			fmt.Printf("Environment variable values must be a valid JSON\n%s\n", err)
-			os.Exit(1)
-		}
-
-	}
-
+	// ...
 	baseDir := c.String("docker-volume-basedir")
 	checkWorkingDirExist := false
 	if baseDir == "" {
@@ -89,189 +51,69 @@ func start(c *cli.Context) {
 		checkWorkingDirExist = true
 	}
 
-	log.Printf("Successfully parsed %s", filename)
-
-	// Create a new HTTP router to mount the functions on
-	router := mux.NewRouter()
+	// Create a new router
+	mux := router.NewServerlessRouter()
 
 	functions := template.GetAllAWSServerlessFunctionResources()
 
-	// Keep track of successfully mounted functions, used for error reporting
-	mounts := []mount{}
-	endpointCount := 0
-
 	for name, function := range functions {
 
-		var events []cloudformation.AWSServerlessFunction_ApiEvent
-		for _, event := range function.Events {
-			if event.Type == "Api" {
-				if event.Properties.ApiEvent != nil {
-					events = append(events, *event.Properties.ApiEvent)
-				}
+		// Initiate a new Lambda runtime
+		runt, err := NewRuntime(NewRuntimeOpt{
+			LogicalID:            name,
+			Function:             function,
+			Logger:               stderr,
+			EnvOverrideFile:      c.String("env-vars"),
+			Basedir:              baseDir,
+			CheckWorkingDirExist: checkWorkingDirExist,
+			DebugPort:            c.String("debug-port"),
+		})
+
+		// Check there wasn't a problem initiating the Lambda runtime
+		if err != nil {
+			if err == ErrRuntimeNotSupported {
+				log.Printf("Ignoring %s (%s) due to unsupported runtime (%s)\n", name, function.Handler, function.Runtime)
+				continue
+			} else {
+				log.Printf("Ignoring %s (%s) due to %s runtime init error: %s\n", name, function.Handler, function.Runtime, err)
+				continue
 			}
 		}
 
-		for _, event := range events {
-
-			endpointCount++
-
-			// Find the env-vars map for the function
-			funcEnvVarsOverrides := envVarsOverrides[name]
-
-			runt, err := NewRuntime(NewRuntimeOpt{
-				Function:             function,
-				EnvVarsOverrides:     funcEnvVarsOverrides,
-				Basedir:              filepath.Dir(filename),
-				CheckWorkingDirExist: checkWorkingDirExist,
-				DebugPort:            c.String("debug-port"),
-			})
-			if err != nil {
-				if err == ErrRuntimeNotSupported {
-					log.Printf("Ignoring %s due to unsupported runtime (%s)\n", function.Handler, function.Runtime)
-					continue
-				} else {
-					log.Printf("Ignoring %s due to %s runtime init error: %s\n", function.Handler, function.Runtime, err)
-					continue
-				}
+		// Add this AWS::Serverless::Function to the HTTP router
+		if err := mux.AddFunction(&function, runt.InvokeHTTP()); err != nil {
+			if err == router.ErrNoEventsFound {
+				log.Printf("Ignoring %s (%s) as no API event sources are defined", name, function.Handler)
 			}
-
-			// Work out which HTTP methods to respond to
-			methods := getHTTPMethods(event.Method)
-
-			// Keep track of this successful mount, for displaying to the user
-			mounts = append(mounts, mount{
-				Handler:  function.Handler,
-				Runtime:  function.Runtime,
-				Endpoint: event.Path,
-				Methods:  methods,
-			})
-
-			router.HandleFunc(event.Path, func(w http.ResponseWriter, r *http.Request) {
-
-				var wg sync.WaitGroup
-
-				w.Header().Set("Content-Type", "application/json")
-
-				event, err := NewEvent(r)
-				if err != nil {
-					msg := fmt.Sprintf("Error invoking %s runtime: %s", function.Runtime, err)
-					log.Println(msg)
-					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte(`{ "message": "Internal server error" }`))
-					return
-				}
-
-				eventJSON, err := event.JSON()
-				if err != nil {
-					msg := fmt.Sprintf("Error invoking %s runtime: %s", function.Runtime, err)
-					log.Println(msg)
-					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte(`{ "message": "Internal server error" }`))
-					return
-				}
-
-				stdoutTxt, stderrTxt, err := runt.Invoke(eventJSON)
-				if err != nil {
-					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte(`{ "message": "Internal server error" }`))
-					return
-				}
-
-				wg.Add(1)
-				go func() {
-
-					result, err := ioutil.ReadAll(stdoutTxt)
-					if err != nil {
-						w.WriteHeader(http.StatusInternalServerError)
-						w.Write([]byte(`{ "message": "Internal server error" }`))
-						wg.Done()
-						return
-					}
-
-					// At this point, we need to see whether the response is in the format
-					// of a Lambda proxy response (inc statusCode / body), and if so, handle it
-					// otherwise just copy the whole output back to the http.ResponseWriter
-					proxy := &struct {
-						StatusCode int               `json:"statusCode"`
-						Headers    map[string]string `json:"headers"`
-						Body       json.Number       `json:"body"`
-					}{}
-
-					if err := json.Unmarshal(result, proxy); err != nil || (proxy.StatusCode == 0 && len(proxy.Headers) == 0 && proxy.Body == "") {
-						// This is not a proxy integration function, as the response doesn't container headers, statusCode or body.
-						// Return HTTP 501 (Internal Server Error) to match Lambda behaviour
-						fmt.Fprintf(os.Stderr, color.RedString("ERROR: Function %s returned an invalid response (must include one of: body, headers or statusCode in the response object)\n"), name)
-						w.WriteHeader(http.StatusInternalServerError)
-						w.Write([]byte(`{ "message": "Internal server error" }`))
-						wg.Done()
-						return
-					}
-
-					// Set any HTTP headers requested by the proxy function
-					if len(proxy.Headers) > 0 {
-						for key, value := range proxy.Headers {
-							w.Header().Set(key, value)
-						}
-					}
-
-					// This is a proxy function, so set the http status code and return the body
-					if proxy.StatusCode != 0 {
-						w.WriteHeader(proxy.StatusCode)
-					}
-
-					w.Write([]byte(proxy.Body))
-					wg.Done()
-
-				}()
-
-				wg.Add(1)
-				go func() {
-					// Finally, copy the container stderr (runtime logs) to the console stderr
-					io.Copy(stderr, stderrTxt)
-					wg.Done()
-				}()
-
-				wg.Wait()
-
-				runt.CleanUp()
-
-			}).Methods(methods...)
-
 		}
+
 	}
 
-	if len(mounts) < 1 {
-
+	// Check we actually mounted some functions on our HTTP router
+	if len(mux.Mounts()) < 1 {
 		if len(functions) < 1 {
 			fmt.Fprintf(stderr, "ERROR: No Serverless functions were found in your SAM template.\n")
 			os.Exit(1)
 		}
-
-		if endpointCount < 1 {
-			fmt.Fprintf(stderr, "ERROR: None of the Serverless functions in your SAM template have valid API event sources.\n")
-			os.Exit(1)
-		}
-
 		fmt.Fprintf(stderr, "ERROR: None of the Serverless functions in your SAM template were able to be mounted. See above for errors.\n")
 		os.Exit(1)
-
 	}
 
 	fmt.Fprintf(stderr, "\n")
 
 	// Mount static files
 	if c.String("static-dir") != "" {
-		public, err := getWorkingDir(baseDir, c.String("static-dir"), checkWorkingDirExist)
+		static, err := getWorkingDir(baseDir, c.String("static-dir"), checkWorkingDirExist)
 		if err != nil {
 			log.Printf("WARNING: Could not mount static files: %s\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Mounting static files from %s at /\n", public)
-			router.PathPrefix("/").Handler(http.FileServer(http.Dir(public)))
+			fmt.Fprintf(os.Stderr, "Mounting static files from %s at /\n", static)
+			mux.AddStaticDir(static, "/")
 		}
 	}
 
-	for _, mount := range mounts {
-		msg := fmt.Sprintf("Mounting %s (%s) at http://%s:%s%s %s", mount.Handler, mount.Runtime, c.String("host"), c.String("port"), mount.Endpoint, mount.Methods)
+	for _, mount := range mux.Mounts() {
+		msg := fmt.Sprintf("Mounting %s (%s) at http://%s:%s%s %s", mount.Function.Handler, mount.Function.Runtime, c.String("host"), c.String("port"), mount.Path, mount.Methods())
 		fmt.Fprintf(os.Stderr, "%s\n", msg)
 	}
 
@@ -282,16 +124,7 @@ func start(c *cli.Context) {
 	fmt.Fprintf(stderr, "SAM CLI if you update your AWS SAM template.\n")
 	fmt.Fprintf(stderr, "\n")
 
-	log.Fatal(http.ListenAndServe(c.String("host")+":"+c.String("port"), router))
+	// Start the HTTP listener
+	log.Fatal(http.ListenAndServe(c.String("host")+":"+c.String("port"), mux.Router()))
 
-}
-
-// getHttpMethods returns the HTTP method(s) supported by an API event source
-func getHTTPMethods(input string) []string {
-	switch input {
-	case "any":
-		return []string{"OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"}
-	default:
-		return []string{strings.ToUpper(input)}
-	}
 }

--- a/start.go
+++ b/start.go
@@ -58,6 +58,11 @@ func start(c *cli.Context) {
 
 	for name, function := range functions {
 
+		cwd := filepath.Dir(filename)
+		if c.String("docker-volume-basedir") != "" {
+			cwd = c.String("docker-volume-basedir")
+		}
+
 		// Initiate a new Lambda runtime
 		runt, err := NewRuntime(NewRuntimeOpt{
 			Cwd:             cwd,

--- a/test/environment-overrides.json
+++ b/test/environment-overrides.json
@@ -1,0 +1,5 @@
+{
+    "IoTFunction": {
+        "TABLE_NAME": "OVERRIDE_TABLE"
+    }
+}


### PR DESCRIPTION
This change takes a lot of the logic out of start.go for HTTP handling, and moves it to a new, separate 'router' package.

It also moves all of the environment handling out into a separate file (env.go and env_test.go), to make that a lot cleaner and remove duplication. These changes makes for a much smaller start.go, with far less logic.

The new HTTP router implementation looks like this:

```go
// initiate a new router
r := router.NewServerlessRouter()

// Add a AWS::Serverless::Function to it
r.AddFunction(someServerlessFunction)

// Add a AWS::Serverless::Api to it
r.AddAPI(someServerlessApi)

// Add a static files dir
r.AddStaticDir("public/", "/")

// Pass it to Go's HTTP pkg for serving
http.ListenAndServe("0.0.0.0:3000", r.Router()))
```

As the router impementation isn't a mega-method-of-doom anymore, it's
much, much easier to unit test. I've included quite a few tests already.

This doesn't implement support for `AWS::Serverless::API` and swagger, however it makes it much easier to implement. The AWSServerlessAPI object in `router/api.go` just needs to return it's mountpoints via the `func (api *AWSServerlessAPI) Mounts() []*ServerlessRouterMount` function (similar to how the `router/function.go` is doing it currently).