### PR TITLE
Provide a flag to skip pulling images (Issue #67)

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -121,6 +121,7 @@ func invoke(c *cli.Context) {
 		Basedir:              baseDir,
 		CheckWorkingDirExist: checkWorkingDirExist,
 		DebugPort:            c.String("debug-port"),
+		SkipPullImage:        c.Bool("skip-pull-image"),
 	})
 	if err != nil {
 		log.Fatalf("Could not initiate %s runtime: %s\n", function.Runtime, err)

--- a/main.go
+++ b/main.go
@@ -96,7 +96,13 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
-					},
+						cli.BoolFlag {
+							Name: "skip-pull-image, p",
+							Usage: "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
+							EnvVar: "SAM_SKIP_PULL_IMAGE",
+						},
+	
+				},
 				},
 				cli.Command{
 					Name:   "invoke",
@@ -135,6 +141,12 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
+						cli.BoolFlag {
+							Name: "skip-pull-image, p",
+							Usage: "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
+							EnvVar: "SAM_SKIP_PULL_IMAGE",
+						},
+	
 					},
 				},
 				cli.Command{

--- a/runtime.go
+++ b/runtime.go
@@ -98,6 +98,7 @@ type NewRuntimeOpt struct {
 	Basedir              string
 	CheckWorkingDirExist bool
 	DebugPort            string
+	SkipPullImage        bool
 }
 
 // NewRuntime instantiates a Lambda runtime container
@@ -144,35 +145,51 @@ func NewRuntime(opt NewRuntimeOpt) (Invoker, error) {
 		return nil, err
 	}
 
-	log.Printf("Fetching %s image for %s runtime...\n", r.Image, opt.Function.Runtime)
-	progress, err := cli.ImagePull(r.Context, r.Image, types.ImagePullOptions{})
-	if len(images) < 0 && err != nil {
-		log.Fatalf("Could not fetch %s Docker image\n%s", r.Image, err)
-		return nil, err
+	// By default, pull images unless we are told not to 
+	pullImage := true 
+	
+	if (opt.SkipPullImage) {
+		log.Printf("Requested to skip pulling images ...\n")
+		pullImage = false
 	}
 
-	if err != nil {
-		log.Printf("Could not fetch %s Docker image: %s\n", r.Image, err)
-	} else {
+	// However, if we don't have the image we will need it...
+	if (len(images) == 0) {
+		log.Printf("Runtime image missing, will pull....\n")
+		pullImage = true
+	}
 
-		// Use Docker's standard progressbar to show image pull progress.
-		// However there is a bug that we are working around. We'll do the same
-		// as Docker does, and temporarily set the TERM to a non-existant
-		// terminal
-		// More info here:
-		// https://github.com/Nvveen/Gotty/pull/1
+	if (pullImage) {	
+		log.Printf("Fetching %s image for %s runtime...\n", r.Image, opt.Function.Runtime)
+		progress, err := cli.ImagePull(r.Context, r.Image, types.ImagePullOptions{})
+		if len(images) < 0 && err != nil {
+			log.Fatalf("Could not fetch %s Docker image\n%s", r.Image, err)
+			return nil, err
+		}
 
-		origTerm := os.Getenv("TERM")
-		os.Setenv("TERM", "eifjccgifcdekgnbtlvrgrinjjvfjggrcudfrriivjht")
-		defer os.Setenv("TERM", origTerm)
+		if err != nil {
+			log.Printf("Could not fetch %s Docker image: %s\n", r.Image, err)
+		} else {
 
-		// Show the Docker pull messages in green
-		color.Output = colorable.NewColorableStderr()
-		color.Set(color.FgGreen)
-		defer color.Unset()
+			// Use Docker's standard progressbar to show image pull progress.
+			// However there is a bug that we are working around. We'll do the same
+			// as Docker does, and temporarily set the TERM to a non-existant
+			// terminal
+			// More info here:
+			// https://github.com/Nvveen/Gotty/pull/1
 
-		jsonmessage.DisplayJSONMessagesStream(progress, os.Stderr, os.Stderr.Fd(), term.IsTerminal(os.Stderr.Fd()), nil)
+			origTerm := os.Getenv("TERM")
+			os.Setenv("TERM", "eifjccgifcdekgnbtlvrgrinjjvfjggrcudfrriivjht")
+			defer os.Setenv("TERM", origTerm)
 
+			// Show the Docker pull messages in green
+			color.Output = colorable.NewColorableStderr()
+			color.Set(color.FgGreen)
+			defer color.Unset()
+
+			jsonmessage.DisplayJSONMessagesStream(progress, os.Stderr, os.Stderr.Fd(), term.IsTerminal(os.Stderr.Fd()), nil)
+
+		}
 	}
 
 	return r, nil

--- a/start.go
+++ b/start.go
@@ -117,13 +117,13 @@ func start(c *cli.Context) {
 
 			// Find the env-vars map for the function
 			funcEnvVarsOverrides := envVarsOverrides[name]
-
 			runt, err := NewRuntime(NewRuntimeOpt{
 				Function:             function,
 				EnvVarsOverrides:     funcEnvVarsOverrides,
 				Basedir:              filepath.Dir(filename),
 				CheckWorkingDirExist: checkWorkingDirExist,
 				DebugPort:            c.String("debug-port"),
+				SkipPullImage:        c.Bool("skip-pull-image"),
 			})
 			if err != nil {
 				if err == ErrRuntimeNotSupported {


### PR DESCRIPTION
Add a flag to instruct SAM to avoid downloading images unless needed (i.e runtime image doesn't exist locally) -- dramatically improves runtime 