### PR TITLE
Add docker containers to existing docker network

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,20 @@ In order to setup Visual Studio Code for debugging with AWS SAM Local, use the f
 
 #### Debugging Python functions
 
-Unlike Node.JS and Java, Python requires you to enable remote debugging in your Lambda function code. If you enable debugging with `--debug-port` or `-d` for a function that uses one of the Python runtimes, SAM Local will just map through that port from your host machine through to the Lambda runtime container. You will need to enable remote debugging in your function code. To do this, use a python package such as [remote-pdb](https://pypi.python.org/pypi/remote-pdb). When configuring the host the debugger listens on in your code, make sure to use `0.0.0.0` not `127.0.0.1` to allow Docker to map through the port to your host machine. 
+Unlike Node.JS and Java, Python requires you to enable remote debugging in your Lambda function code. If you enable debugging with `--debug-port` or `-d` for a function that uses one of the Python runtimes, SAM Local will just map through that port from your host machine through to the Lambda runtime container. You will need to enable remote debugging in your function code. To do this, use a python package such as [remote-pdb](https://pypi.python.org/pypi/remote-pdb). When configuring the host the debugger listens on in your code, make sure to use `0.0.0.0` not `127.0.0.1` to allow Docker to map through the port to your host machine.
+
+### Connecting to docker network
+Both `sam local invoke` and `sam local start-api` support connecting the create lambda docker containers to an existing docker network.
+
+To connect the containers to an existing docker network, you can use the `--docker-network` command-line argument or the `SAM_DOCKER_NETWORK` environment variable along with the name or id of the docker network you wish to connect to.
+
+```bash
+# Invoke a function locally and connect to a docker network
+$ sam local invoke --docker-network my-custom-network <function logical id>
+
+# Start local API Gateway and connect all containers to a docker network
+$ sam local start-api --docker-network b91847306671 -d 5858
+```
 
 ### Validate SAM templates
 

--- a/invoke.go
+++ b/invoke.go
@@ -122,6 +122,7 @@ func invoke(c *cli.Context) {
 		CheckWorkingDirExist: checkWorkingDirExist,
 		DebugPort:            c.String("debug-port"),
 		SkipPullImage:        c.Bool("skip-pull-image"),
+		DockerNetwork:        c.String("docker-network"),
 	})
 	if err != nil {
 		log.Fatalf("Could not initiate %s runtime: %s\n", function.Runtime, err)

--- a/main.go
+++ b/main.go
@@ -96,6 +96,13 @@ func main() {
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
 						},
+						cli.StringFlag{
+							Name: "docker-network",
+							Usage: "Optional. Specifies the name or id of an existing docker network to lambda docker " +
+								"containers should connect to, along with the default bridge network. If not specified, " +
+								"the lambdadocker containers will only connect to the default bridge docker network.",
+							EnvVar: "SAM_DOCKER_NETWORK",
+						},
 						cli.BoolFlag{
 							Name:   "skip-pull-image",
 							Usage:  "Optional. Specify whether SAM should skip pulling down the latest Docker image. Default is false.",
@@ -139,6 +146,13 @@ func main() {
 							Usage: "Optional. Specifies the location basedir where the SAM file exists. If the Docker is running on a remote machine, " +
 								"you must mount the path where the SAM file exists on the docker machine and modify this value to match the remote machine.",
 							EnvVar: "SAM_DOCKER_VOLUME_BASEDIR",
+						},
+						cli.StringFlag{
+							Name: "docker-network",
+							Usage: "Optional. Specifies the name or id of an existing docker network to lambda docker " +
+								"containers should connect to, along with the default bridge network. If not specified, " +
+								"the lambdadocker containers will only connect to the default bridge docker network.",
+							EnvVar: "SAM_DOCKER_NETWORK",
 						},
 						cli.BoolFlag{
 							Name:   "skip-pull-image",

--- a/runtime.go
+++ b/runtime.go
@@ -55,6 +55,7 @@ type Runtime struct {
 	Context         context.Context
 	Client          *client.Client
 	TimeoutTimer    *time.Timer
+	DockerNetwork   string
 }
 
 var (
@@ -99,6 +100,7 @@ type NewRuntimeOpt struct {
 	CheckWorkingDirExist bool
 	DebugPort            string
 	SkipPullImage        bool
+	DockerNetwork        string
 }
 
 // NewRuntime instantiates a Lambda runtime container
@@ -133,6 +135,7 @@ func NewRuntime(opt NewRuntimeOpt) (Invoker, error) {
 		DebugPort:       opt.DebugPort,
 		Context:         context.Background(),
 		Client:          cli,
+		DockerNetwork:   opt.DockerNetwork,
 	}
 
 	// Check if we have the required Docker image for this runtime
@@ -299,11 +302,11 @@ func (r *Runtime) Invoke(event string) (io.Reader, io.Reader, error) {
 
 	r.ID = resp.ID
 
-	if os.Getenv("AWS_SAM_DOCKER_NETWORK") != "" {
-		if err := r.Client.NetworkConnect(r.Context, os.Getenv("AWS_SAM_DOCKER_NETWORK"), resp.ID, nil); err != nil {
+	if r.DockerNetwork != "" {
+		if err := r.Client.NetworkConnect(r.Context, r.DockerNetwork, resp.ID, nil); err != nil {
 			return nil, nil, err
 		}
-		log.Printf("Connecting container %s to network %s", resp.ID, os.Getenv("AWS_SAM_DOCKER_NETWORK"))
+		log.Printf("Connecting container %s to network %s", resp.ID, r.DockerNetwork)
 	}
 
 	// Invoke the container

--- a/runtime.go
+++ b/runtime.go
@@ -299,6 +299,13 @@ func (r *Runtime) Invoke(event string) (io.Reader, io.Reader, error) {
 
 	r.ID = resp.ID
 
+	if os.Getenv("AWS_SAM_DOCKER_NETWORK") != "" {
+		if err := r.Client.NetworkConnect(r.Context, os.Getenv("AWS_SAM_DOCKER_NETWORK"), resp.ID, nil); err != nil {
+			return nil, nil, err
+		}
+		log.Printf("Connecting container %s to network %s", resp.ID, os.Getenv("AWS_SAM_DOCKER_NETWORK"))
+	}
+
 	// Invoke the container
 	if err := r.Client.ContainerStart(r.Context, resp.ID, types.ContainerStartOptions{}); err != nil {
 		return nil, nil, err

--- a/start.go
+++ b/start.go
@@ -124,6 +124,7 @@ func start(c *cli.Context) {
 				CheckWorkingDirExist: checkWorkingDirExist,
 				DebugPort:            c.String("debug-port"),
 				SkipPullImage:        c.Bool("skip-pull-image"),
+				DockerNetwork:        c.String("docker-network"),
 			})
 			if err != nil {
 				if err == ErrRuntimeNotSupported {


### PR DESCRIPTION
In our set-up, we locally start our docker containers in a network.
To allow the lambda functions started up by sam-local to access these docker containers, we needed to put the created lambda docker containers in the same network.

We've made a small change to sam-local so that you can (optionally) set an environment variable and enter the name or id of the docker network you want to add the containers to.

We thought this might be useful to be added to the real sam-local, hence this pull request.