### PR TITLE
Start-Api does not correctly use docker-volume-basedir property

### DIFF
--- a/start.go
+++ b/start.go
@@ -120,7 +120,7 @@ func start(c *cli.Context) {
 			runt, err := NewRuntime(NewRuntimeOpt{
 				Function:             function,
 				EnvVarsOverrides:     funcEnvVarsOverrides,
-				Basedir:              filepath.Dir(filename),
+				Basedir:              baseDir,
 				CheckWorkingDirExist: checkWorkingDirExist,
 				DebugPort:            c.String("debug-port"),
 				SkipPullImage:        c.Bool("skip-pull-image"),


### PR DESCRIPTION
When using the docker-volume-basedir cli property (or the equivalent env variable), the basedir is not passed on to the NewRuntime-object when using start-api instead of invoke, but the directory of the template.yaml is used instead. This results in remote docker not working when using the start-api option.

This PR should fix that.