### PR TITLE
Add warning when no credentials found. 

### DIFF
--- a/env.go
+++ b/env.go
@@ -139,7 +139,10 @@ func getSessionOrDefaultCreds(profile string) map[string]string {
 	opts.Profile = profile
 	// Obtain AWS credentials and pass them through to the container runtime via env variables
 	if sess, err := session.NewSessionWithOptions(opts); err == nil {
-		if creds, err := sess.Config.Credentials.Get(); err == nil {
+		creds, err := sess.Config.Credentials.Get()
+		if err != nil {
+			log.Printf("WARNING: No AWS credentials found. Missing credentials may lead to slow startup times as detailed in https://github.com/awslabs/aws-sam-local/issues/134")
+		} else {
 			if *sess.Config.Region != "" {
 				result["region"] = *sess.Config.Region
 			}


### PR DESCRIPTION
On a machine with no AWS credentials configured, each execution takes an additional 20 seconds to complete. This time is spent waiting for the connection to 169.254.169.254 to time out.

I believe this is the cause of issue https://github.com/awslabs/aws-sam-local/issues/134

If aws-sam-local is rarely run on an ec2 instance, it may be better to disable the EC2RoleProvider by default.