### PR TITLE
Allow execution of AWS::Lambda::Function via the invoke subcommand

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/awslabs/goformation/cloudformation"
+)
+
+// addCloudformationLambdaFunctions converts all Cloudformation Lambda functions to Serverless functions. On name collisions, existing
+// serverless functions are preserved.
+func addCloudformationLambdaFunctions(template *cloudformation.Template, functions map[string]cloudformation.AWSServerlessFunction) {
+	// convert all lambda functions to serverless functions so that invoke works for them
+	for n, f := range template.GetAllAWSLambdaFunctionResources() {
+		if _, found := functions[n]; !found {
+			functions[n] = lambdaToServerless(f)
+		}
+	}
+}
+
+// dlqTypeEx is used to extract the DLQ type from an ARN
+var dlqTypeEx = regexp.MustCompile(`^arn:aws(?:-[\\w]+)*:(sns|sqs):([a-zA-Z_0-9+=,.@\-/:]+)$`)
+
+// lambdaToServerless converts a Cloudformation lambda to its Serverless counterpart. The conversion makes the following assumptions:
+// * codeUri is set to nil in order to use the local code and not the remote one
+// * no events are associated with the serverless function
+// * no policies are added because a role is already specified
+func lambdaToServerless(lambda cloudformation.AWSLambdaFunction) (serverless cloudformation.AWSServerlessFunction) {
+	// serverless policies are not needed because lambdas have a role
+	serverless.Policies = nil
+
+	// no events are associated with the function
+	serverless.Events = nil
+
+	// codeUri is set to nil in order to get the code locally and not from a remote source
+	serverless.CodeUri = nil
+
+	serverless.FunctionName = lambda.FunctionName
+	serverless.Description = lambda.Description
+	serverless.Handler = lambda.Handler
+	serverless.Timeout = lambda.Timeout
+	serverless.KmsKeyArn = lambda.KmsKeyArn
+	serverless.Role = lambda.Role
+	serverless.Runtime = lambda.Runtime
+	serverless.MemorySize = lambda.MemorySize
+
+	if lambda.DeadLetterConfig != nil {
+		dlqType := "SQS"
+		match := dlqTypeEx.FindAllStringSubmatch(lambda.DeadLetterConfig.TargetArn, -1)
+		if len(match) > 0 {
+			dlqType = match[0][1]
+		}
+
+		serverless.DeadLetterQueue = &cloudformation.AWSServerlessFunction_DeadLetterQueue{
+			TargetArn: lambda.DeadLetterConfig.TargetArn,
+			Type:      strings.ToUpper(dlqType),
+		}
+	}
+
+	if len(lambda.Tags) > 0 {
+		tags := make(map[string]string)
+		for _, t := range lambda.Tags {
+			tags[t.Key] = t.Value
+		}
+		serverless.Tags = tags
+	}
+
+	if lambda.TracingConfig != nil {
+		serverless.Tracing = lambda.TracingConfig.Mode
+	}
+
+	if lambda.Environment != nil {
+		serverless.Environment = &cloudformation.AWSServerlessFunction_FunctionEnvironment{
+			Variables: lambda.Environment.Variables,
+		}
+	}
+
+	if lambda.VpcConfig != nil {
+		serverless.VpcConfig = &cloudformation.AWSServerlessFunction_VpcConfig{
+			SecurityGroupIds: lambda.VpcConfig.SecurityGroupIds,
+			SubnetIds:        lambda.VpcConfig.SubnetIds,
+		}
+	}
+
+	return
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"github.com/awslabs/goformation"
+	"github.com/awslabs/goformation/cloudformation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Convert Cloudformation Lambda functions to Serverless", func() {
+
+	Context("with normal input", func() {
+
+		It("converts an empty function", func() {
+			f := cloudformation.AWSLambdaFunction{}
+			expected := cloudformation.AWSServerlessFunction{}
+			Expect(lambdaToServerless(f)).To(Equal(expected))
+		})
+
+		It("converts a function", func() {
+			f := cloudformation.AWSLambdaFunction{
+				FunctionName: "foo",
+				Description:  "desc",
+				Handler:      "index.js",
+				Timeout:      30,
+				Runtime:      "nodejs6.10",
+				MemorySize:   300,
+				Role:         "arn:aws:iam::123456789012:role/S3Access",
+				KmsKeyArn:    "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+				DeadLetterConfig: &cloudformation.AWSLambdaFunction_DeadLetterConfig{
+					TargetArn: "arn:aws:sns:us-east-1:123456789012:my_corporate_topic:02034b43-fefa-4e07-a5eb-3be56f8c54ce",
+				},
+				Tags: []cloudformation.Tag{{Key: "key", Value: "value"}},
+				TracingConfig: &cloudformation.AWSLambdaFunction_TracingConfig{
+					Mode: "PassThrough",
+				},
+				Environment: &cloudformation.AWSLambdaFunction_Environment{
+					Variables: map[string]string{"k1": "v1"},
+				},
+				VpcConfig: &cloudformation.AWSLambdaFunction_VpcConfig{
+					SecurityGroupIds: []string{"sg-edcd9784"},
+					SubnetIds:        []string{"subnet"},
+				},
+			}
+			expected := cloudformation.AWSServerlessFunction{
+				CodeUri:      nil,
+				Events:       nil,
+				Policies:     nil,
+				FunctionName: "foo",
+				Description:  "desc",
+				Handler:      "index.js",
+				Timeout:      30,
+				Runtime:      "nodejs6.10",
+				MemorySize:   300,
+				Role:         "arn:aws:iam::123456789012:role/S3Access",
+				KmsKeyArn:    "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+				DeadLetterQueue: &cloudformation.AWSServerlessFunction_DeadLetterQueue{
+					TargetArn: "arn:aws:sns:us-east-1:123456789012:my_corporate_topic:02034b43-fefa-4e07-a5eb-3be56f8c54ce",
+					Type:      "SNS",
+				},
+				Tags:    map[string]string{"key": "value"},
+				Tracing: "PassThrough",
+				Environment: &cloudformation.AWSServerlessFunction_FunctionEnvironment{
+					Variables: map[string]string{"k1": "v1"},
+				},
+				VpcConfig: &cloudformation.AWSServerlessFunction_VpcConfig{
+					SecurityGroupIds: []string{"sg-edcd9784"},
+					SubnetIds:        []string{"subnet"},
+				},
+			}
+
+			Expect(lambdaToServerless(f)).To(Equal(expected))
+		})
+
+	})
+
+	Context("with existing template", func() {
+
+		functions := map[string]cloudformation.AWSServerlessFunction{
+			"ExistingFunction": cloudformation.AWSServerlessFunction{},
+		}
+		const input = `{
+            "Resources": {
+              "ExistingFunction": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                  "FunctionName": "ExistingFunction",
+                  "Handler": "com.foo.bar.Dispatcher::handleRequest"
+                }
+              },
+              "Func1": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                  "FunctionName": "Func1",
+                  "Handler": "com.foo.bar.Dispatcher::handleRequest"
+                }
+              }
+            }
+          }`
+
+		template, err := goformation.ParseJSON([]byte(input))
+
+		It("parses correctly", func() {
+			Expect(err).To(BeNil())
+			Expect(template).To(Not(BeNil()))
+			lambdas := template.GetAllAWSLambdaFunctionResources()
+			Expect(lambdas).To(HaveLen(2))
+			Expect(lambdas).To(HaveKey("Func1"))
+			Expect(lambdas).To(HaveKey("ExistingFunction"))
+		})
+
+		if template != nil {
+			addCloudformationLambdaFunctions(template, functions)
+		}
+
+		It("adds lambda functions that don't clash", func() {
+			Expect(functions).To(HaveLen(2))
+			Expect(functions).To(HaveKey("Func1"))
+			Expect(functions).To(HaveKey("ExistingFunction"))
+		})
+
+		It("ignores lambda functions which already exist", func() {
+			Expect(functions).To(HaveKeyWithValue("ExistingFunction", Equal(cloudformation.AWSServerlessFunction{})))
+		})
+
+	})
+})

--- a/invoke.go
+++ b/invoke.go
@@ -49,6 +49,9 @@ func invoke(c *cli.Context) {
 	// logical ID matches the first CLI argument, or if they only have a single function
 	// defined, and don't specify a name, then just use that function.
 	functions := template.GetAllAWSServerlessFunctionResources()
+
+	addCloudformationLambdaFunctions(template, functions)
+
 	function, found := functions[name]
 	if !found {
 		if len(functions) == 1 && name == "" {


### PR DESCRIPTION
This allows customers with CloudFormation templates that contain classic Lambda functions to test them via SAM local