### PR TITLE
fix(deploy, package): propagate non-zero exit codes

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -33,6 +33,7 @@ func deploy() {
 	go io.Copy(os.Stderr, stderr)
 	go io.Copy(os.Stdout, stdout)
 
-	cmd.Wait()
-
+	if err := cmd.Wait(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/package.go
+++ b/package.go
@@ -33,6 +33,7 @@ func pkg() {
 	go io.Copy(os.Stderr, stderr)
 	go io.Copy(os.Stdout, stdout)
 
-	cmd.Wait()
-
+	if err := cmd.Wait(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Because the err returned by `cmd.Wait()` wasn't checked `sam package` and `sam
deploy` would always return exit code 0 even if the aws cli cmd had a non-zero
exit code.

This commit checks the error and calls `log.Fatal()`. While this prints the
original exit code to stderr (at least on macOS) this does not propagate the
original error code but exits with 1. This is because there seems to be no easy
os independent way of getting the exit code. Anyway this should do it for all
sane use cases.

Closes #178 