### PR TITLE
fix(event): set PathParameters explicitly to nill if non

### DIFF
--- a/event.go
+++ b/event.go
@@ -70,6 +70,11 @@ func NewEvent(req *http.Request) (*Event, error) {
 		}
 	}
 
+	pathParams := mux.Vars(req)
+	if len(pathParams) == 0 {
+		pathParams = nil
+	}
+
 	event := &Event{
 		HTTPMethod:        req.Method,
 		Body:              string(body),
@@ -77,7 +82,7 @@ func NewEvent(req *http.Request) (*Event, error) {
 		QueryStringParams: query,
 		Path:              req.URL.Path,
 		Resource:          req.URL.Path,
-		PathParameters:    mux.Vars(req),
+		PathParameters:    pathParams,
 	}
 
 	event.RequestContext.Identity.SourceIP = req.RemoteAddr

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/awslabs/aws-sam-local/router"
+	"github.com/awslabs/goformation/cloudformation"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Event", func() {
+	Describe("PathParameters", func() {
+		var r *router.ServerlessRouter
+		BeforeEach(func() {
+			r = router.NewServerlessRouter(false)
+		})
+
+		Context("with path parameters on the route", func() {
+			function := &cloudformation.AWSServerlessFunction{
+				Runtime: "nodejs6.10",
+				Events: map[string]cloudformation.AWSServerlessFunction_EventSource{
+					"GetRequest": cloudformation.AWSServerlessFunction_EventSource{
+						Type: "Api",
+						Properties: &cloudformation.AWSServerlessFunction_S3EventOrSNSEventOrKinesisEventOrDynamoDBEventOrApiEventOrScheduleEventOrCloudWatchEventEventOrIoTRuleEventOrAlexaSkillEvent{
+							ApiEvent: &cloudformation.AWSServerlessFunction_ApiEvent{
+								Path:   "/get",
+								Method: "get",
+							},
+						},
+					},
+					"GetRequestsWithParams": cloudformation.AWSServerlessFunction_EventSource{
+						Type: "Api",
+						Properties: &cloudformation.AWSServerlessFunction_S3EventOrSNSEventOrKinesisEventOrDynamoDBEventOrApiEventOrScheduleEventOrCloudWatchEventEventOrIoTRuleEventOrAlexaSkillEvent{
+							ApiEvent: &cloudformation.AWSServerlessFunction_ApiEvent{
+								Path:   "/get/{parameter}",
+								Method: "get",
+							},
+						},
+					},
+				},
+			}
+
+			Context("and path parameters on the request", func() {
+				req, _ := http.NewRequest("GET", "/get/1", new(bytes.Buffer))
+
+				It("returns the parameters on the event", func() {
+					r.AddFunction(function, func(w http.ResponseWriter, r *http.Request) {
+						e, _ := NewEvent(r)
+						Expect(e.PathParameters).To(HaveKeyWithValue("parameter", "1"))
+					})
+
+					rec := httptest.NewRecorder()
+					r.Router().ServeHTTP(rec, req)
+				})
+			})
+
+			Context("and no path parameters on the request", func() {
+				req, _ := http.NewRequest("GET", "/get", new(bytes.Buffer))
+
+				It("returns nil for PathParameters on the event", func() {
+					r.AddFunction(function, func(w http.ResponseWriter, r *http.Request) {
+						e, _ := NewEvent(r)
+						Expect(e.PathParameters).To(BeNil())
+					})
+
+					rec := httptest.NewRecorder()
+					r.Router().ServeHTTP(rec, req)
+				})
+			})
+		})
+
+		Context("with no parameters on the route", func() {
+			function := &cloudformation.AWSServerlessFunction{
+				Runtime: "nodejs6.10",
+				Events: map[string]cloudformation.AWSServerlessFunction_EventSource{
+					"GetRequest": cloudformation.AWSServerlessFunction_EventSource{
+						Type: "Api",
+						Properties: &cloudformation.AWSServerlessFunction_S3EventOrSNSEventOrKinesisEventOrDynamoDBEventOrApiEventOrScheduleEventOrCloudWatchEventEventOrIoTRuleEventOrAlexaSkillEvent{
+							ApiEvent: &cloudformation.AWSServerlessFunction_ApiEvent{
+								Path:   "/get",
+								Method: "get",
+							},
+						},
+					},
+				},
+			}
+
+			req, _ := http.NewRequest("GET", "/get", new(bytes.Buffer))
+
+			It("returns nil for PathParameters on the event", func() {
+				r.AddFunction(function, func(w http.ResponseWriter, r *http.Request) {
+					e, _ := NewEvent(r)
+					Expect(e.PathParameters).To(BeNil())
+				})
+
+				rec := httptest.NewRecorder()
+				r.Router().ServeHTTP(rec, req)
+			})
+		})
+	})
+})


### PR DESCRIPTION
As shown by this failing test sam-local returns an empty map if no path parameters are defined on either the request or the route. Sadly this is not the behaviour of API gateway. There it is null which causes untyped scripting languages to work fine locally but crash on AWS.

Even though the [mux docs state differently](https://github.com/gorilla/mux/blob/7625a85c14e615274a4ee4bc8654f72310a563e4/mux.go#L379) `mux.Vars()` doesn't return nil but an empty map if no path parameters are present. This PR sets the PathParameters explicitly to nill if the map returned by `mux.Vars()` is empty.

Closes #173

PS: I'm not much of a gopher so feel free to call me out if I did something stupid.

**Edit:**
Ah! TIL: Go has the concept of nill maps which are read only empty maps. Therefore the mux docs are right. Anyway in this case we need an explicit `nill` I guess.