### PR TITLE
api event is missing the stage property

### DIFF
--- a/event.go
+++ b/event.go
@@ -29,6 +29,7 @@ type RequestContext struct {
 	HTTPMethod   string          `json:"httpMethod,omitempty"`
 	RequestID    string          `json:"requestId,omitempty"`
 	AccountsID   string          `json:"accountId,omitempty"`
+	Stage        string          `json:"stage,omitempty"`
 	Identity     ContextIdentity `json:"identity,omitempty"`
 }
 
@@ -88,6 +89,7 @@ func NewEvent(req *http.Request) (*Event, error) {
 	event.RequestContext.Identity.SourceIP = req.RemoteAddr
 	event.RequestContext.ResourcePath = req.URL.Path
 	event.RequestContext.HTTPMethod = req.Method
+	event.RequestContext.Stage = "prod"
 
 	return event, nil
 

--- a/event_test.go
+++ b/event_test.go
@@ -57,6 +57,20 @@ var _ = Describe("Event", func() {
 					r.Router().ServeHTTP(rec, req)
 				})
 			})
+			
+			Context("and path parameters on the request", func() {
+				req, _ := http.NewRequest("GET", "/get/1", new(bytes.Buffer))
+
+				It("returns stage property with value \"prod\"", func() {
+					r.AddFunction(function, func(w http.ResponseWriter, r *http.Request) {
+						e, _ := NewEvent(r)
+						Expect(e.RequestContext.Stage).To(BeIdenticalTo("prod"))
+					})
+
+					rec := httptest.NewRecorder()
+					r.Router().ServeHTTP(rec, req)
+				})
+			})
 
 			Context("and no path parameters on the request", func() {
 				req, _ := http.NewRequest("GET", "/get", new(bytes.Buffer))


### PR DESCRIPTION
Using [aws-serverless-java-container](https://github.com/awslabs/aws-serverless-java-container) to run a Spring application in a Lambda function I was continuously getting errors. 

## How to reproduce?
1. Checkout and build the [Spring example](https://github.com/awslabs/aws-serverless-java-container/tree/master/samples/spring/pet-store).
2. run with `sam local start-api -t sam.yaml` (latest release and latest develop build)
3. run `curl http://localhost:3000/pets` and get `{"message":"Gateway timeout"}`

## What causes `Gateway timeout`?
It is caused by a Java NullPointerException at `spring-web-4.3.9.RELEASE-sources.jar!/org/springframework/web/util/UrlPathHelper.java:245` originating from `org.springframework.web.util.UrlPathHelper#getPathWithinApplication` because `com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletRequest#getContextPath` requires the stage be set. When I understand the events correctly (and the [event generator](https://github.com/awslabs/aws-sam-local/blob/develop/generate-event.go) supports my assumption) then the stage property *must be set*

## How to fix
I added the fixed string `prod` to the events stage property. I assume for aws-sam-local there is no need for other stages.