### PR TITLE
In the HOWTO.md sample lambda code, check that event.pathParameters e…

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -52,7 +52,7 @@ In order to service these, let's create a Lambda function in `products.js` like 
 
 exports.handler = (event, context, callback) => {
 
-    let id = event.pathParameters.product || false;
+    let id = (event.pathParameters && event.pathParameters.product) || false;
     switch(event.httpMethod){
         
         case "GET":


### PR DESCRIPTION
…xists. It has a null value when the lambda function is invoked via "curl http://localhost:3000/products".

Otherwise, the sample code will not work when invoking the LIST operation.