### PR TITLE
Unify runtime and function timeouts

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -90,6 +90,9 @@ func invoke(c *cli.Context) {
 		cwd = c.String("docker-volume-basedir")
 	}
 
+	// Make the function's timeout match the actual runtime timeout.
+	function.Timeout = c.Int("timeout")
+
 	runt, err := NewRuntime(NewRuntimeOpt{
 		Cwd:             cwd,
 		LogicalID:       name,
@@ -99,6 +102,7 @@ func invoke(c *cli.Context) {
 		DebugPort:       c.String("debug-port"),
 		SkipPullImage:   c.Bool("skip-pull-image"),
 		DockerNetwork:   c.String("docker-network"),
+		TimeoutDuration: c.Int("timeout"),
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,11 @@ func main() {
 							Usage:  "Optional. Specify whether SAM routing is based on prefix or exact matching (e.g. given a function mounted at '/' with prefix routing calls to '/beers' will be routed the function).",
 							EnvVar: "SAM_PREFIX_ROUTING",
 						},
+						cli.IntFlag{
+							Name:  "timeout",
+							Usage: "Optional. Specifies the duration of the Invoker timeout in seconds (default: 3)",
+							Value: 3,
+						},
 					},
 				},
 				cli.Command{
@@ -183,6 +188,11 @@ func main() {
 						cli.StringFlag{
 							Name:  "profile",
 							Usage: "Optional. Specify which AWS credentials profile to use.",
+						},
+						cli.IntFlag{
+							Name:  "timeout",
+							Usage: "Optional. Specifies the duration of the Invoker timeout in seconds (default: 3)",
+							Value: 3,
 						},
 					},
 				},

--- a/runtime.go
+++ b/runtime.go
@@ -60,6 +60,7 @@ type Runtime struct {
 	DebugPort       string
 	Context         context.Context
 	Client          *client.Client
+	TimeoutDuration int
 	TimeoutTimer    *time.Timer
 	Logger          io.Writer
 	DockerNetwork   string
@@ -109,6 +110,7 @@ type NewRuntimeOpt struct {
 	Logger          io.Writer
 	SkipPullImage   bool
 	DockerNetwork   string
+	TimeoutDuration int
 }
 
 // NewRuntime instantiates a Lambda runtime container
@@ -134,6 +136,7 @@ func NewRuntime(opt NewRuntimeOpt) (Invoker, error) {
 		DebugPort:       opt.DebugPort,
 		Context:         context.Background(),
 		Client:          cli,
+		TimeoutDuration: opt.TimeoutDuration,
 		Logger:          opt.Logger,
 		DockerNetwork:   opt.DockerNetwork,
 	}
@@ -361,7 +364,7 @@ func (r *Runtime) Invoke(event string, profile string) (io.Reader, io.Reader, er
 
 func (r *Runtime) setupTimeoutTimer(stdout, stderr io.ReadCloser) {
 	// Start a timer, we'll use this to abort the function if it runs beyond the specified timeout
-	timeout := time.Duration(3) * time.Second
+	timeout := time.Duration(r.TimeoutDuration) * time.Second
 	if r.Function.Timeout > 0 {
 		timeout = time.Duration(r.Function.Timeout) * time.Second
 	}

--- a/start.go
+++ b/start.go
@@ -83,6 +83,9 @@ func start(c *cli.Context) {
 			cwd = c.String("docker-volume-basedir")
 		}
 
+		// Make the function's timeout match the actual runtime timeout.
+		function.Timeout = c.Int("timeout")
+
 		// Initiate a new Lambda runtime
 		runt, err := NewRuntime(NewRuntimeOpt{
 			Cwd:             cwd,
@@ -93,6 +96,7 @@ func start(c *cli.Context) {
 			DebugPort:       c.String("debug-port"),
 			SkipPullImage:   c.Bool("skip-pull-image"),
 			DockerNetwork:   c.String("docker-network"),
+			TimeoutDuration: c.Int("timeout"),
 		})
 
 		// Check there wasn't a problem initiating the Lambda runtime


### PR DESCRIPTION
This closes #253. 

Before this patch, `LamdbaContext.get_remaining_time_in_millis()` would return a negative value because the `CloudFormation.AWSServerlessFunction`'s `Timeout` defaults to zero. 

# BEFORE
```
$ sam local invoke test
2018/01/10 13:51:03 Successfully parsed template.yml
2018/01/10 13:51:03 Connected to Docker 1.35
2018/01/10 13:51:03 Fetching lambci/lambda:python3.6 image for python3.6 runtime...
python3.6: Pulling from lambci/lambda
Digest: sha256:0682e157b34e18cf182b2aaffb501971c7a0c08c785f337629122b7de34e3945
Status: Image is up to date for lambci/lambda:python3.6
2018/01/10 13:51:05 Reading invoke payload from stdin (you can also pass it from file with --event)
{}
2018/01/10 13:51:07 Invoking foo.handler (python3.6)
2018/01/10 13:51:07 Mounting /Users/chris/Projects/foo as /var/task:ro inside runtime container
START RequestId: af1693dd-2091-4402-b644-c9711a24a4da Version: $LATEST
{}
-5
-1008
END RequestId: af1693dd-2091-4402-b644-c9711a24a4da
REPORT RequestId: af1693dd-2091-4402-b644-c9711a24a4da Duration: 1008 ms Billed Duration: 0 ms Memory Size: 0 MB Max Memory Used: 18 MB

null
```

# AFTER
```
$ sam local invoke test
2018/01/10 13:50:36 Successfully parsed template.yml
2018/01/10 13:50:36 Connected to Docker 1.35
2018/01/10 13:50:36 Fetching lambci/lambda:python3.6 image for python3.6 runtime...
python3.6: Pulling from lambci/lambda
Digest: sha256:0682e157b34e18cf182b2aaffb501971c7a0c08c785f337629122b7de34e3945
Status: Image is up to date for lambci/lambda:python3.6
2018/01/10 13:50:37 Reading invoke payload from stdin (you can also pass it from file with --event)
{}
2018/01/10 13:50:40 Invoking foo.handler (python3.6)
2018/01/10 13:50:40 Mounting /Users/chris/Projects/foo as /var/task:ro inside runtime container
START RequestId: dbb4bed8-a8de-4012-9d77-e6ae63eb22ae Version: $LATEST
{}
2991
1989
END RequestId: dbb4bed8-a8de-4012-9d77-e6ae63eb22ae
REPORT RequestId: dbb4bed8-a8de-4012-9d77-e6ae63eb22ae Duration: 1011 ms Billed Duration: 1100 ms Memory Size: 0 MB Max Memory Used: 19 MB

null
```