### PR TITLE
Function timeout and memory size fixes (use SAM specification defaults)

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -292,6 +292,22 @@ func (r *Runtime) Invoke(event string, profile string) (io.Reader, io.Reader, er
 		}
 	}
 
+	// If the timeout hasn't been set for the function in the SAM template
+	// then default to 3 seconds (as per SAM specification).
+	// This needs to be done before environment variables are generated for
+	// the Lambda runtime so that the correct AWS_LAMBDA_FUNCTION_TIMEOUT is used
+	if r.Function.Timeout <= 0 {
+		r.Function.Timeout = 3
+	}
+
+	// If the memory size hasn't been set for the function in the SAM template
+	// then default to 128MB (as per SAM specification).
+	// This needs to be done before environment variables are generated for
+	// the Lambda runtime so that the correct AWS_LAMBDA_FUNCTION_MEMORY_SIZE is used
+	if r.Function.MemorySize <= 0 {
+		r.Function.MemorySize = 128
+	}
+
 	// Define the container options
 	config := &container.Config{
 		WorkingDir:   "/var/task",
@@ -363,11 +379,10 @@ func (r *Runtime) Invoke(event string, profile string) (io.Reader, io.Reader, er
 }
 
 func (r *Runtime) setupTimeoutTimer(stdout, stderr io.ReadCloser) {
+
 	// Start a timer, we'll use this to abort the function if it runs beyond the specified timeout
-	timeout := time.Duration(3) * time.Second
-	if r.Function.Timeout > 0 {
-		timeout = time.Duration(r.Function.Timeout) * time.Second
-	}
+	timeout := time.Duration(r.Function.Timeout) * time.Second
+
 	r.TimeoutTimer = time.NewTimer(timeout)
 	go func() {
 		<-r.TimeoutTimer.C


### PR DESCRIPTION
Fix issue where a template with no AWS::Serverless:Function.Timeout set causes AWS_LAMBDA_FUNCTION_TIMEOUT=0 to be sent to the Lambda runtime. Instead it should default to the SAM specification default (3 seconds). Also included the same default behaviour for the memory size as this was missing too.