### PR TITLE
update README to include upgrade command for npm installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ This will install **`sam`** to your `$GOPATH/bin` folder. Make sure this directo
 aws-sam-local --help
 ```
 
-
 ## Usage
 
 **`sam`** requires a SAM template in order to know how to invoke your function locally, and it's also true for spawning API Gateway locally - If no template is specified `template.yaml` will be used instead.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ sam --version
 
 If you get a permission error when using npm (such as `EACCES: permission denied`), please see the instructions on this page of the NPM documentation: [https://docs.npmjs.com/getting-started/fixing-npm-permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
 
+#### Upgrading via npm
+
+To update **`sam`** once installed via npm:
+
+```bash
+npm update -g aws-sam-local
+```
+
 ### Binary release
 
 We also release the CLI as binaries that you can download and instantly use. You can find them under [Releases] in this repo. In case you cannot find the version or architecture you're looking for you can refer to [Build From Source](#build-from-source) section for build details.
@@ -96,6 +104,7 @@ This will install **`sam`** to your `$GOPATH/bin` folder. Make sure this directo
 ```bash
 aws-sam-local --help
 ```
+
 
 ## Usage
 


### PR DESCRIPTION
The CLI from time to time provides a nag saying there is a newer version of SAM Local available. It then sends you here to find out more information but doesn't provide a command example. This PR fixes that.