### PR TITLE
Use inspect debug protocol for node6 runtime

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -467,7 +467,7 @@ func (r *Runtime) getDebugEntrypoint() (overrides []string) {
 	case runtimeName.nodejs610:
 		overrides = []string{
 			"/var/lang/bin/node",
-			"--debug-brk=" + r.DebugPort,
+			"--inspect-brk=" + r.DebugPort,
 			"--nolazy",
 			"--max-old-space-size=1229",
 			"--max-semi-space-size=76",


### PR DESCRIPTION
Node 6.10 supports the inspector protocol for debugging, which is nicer to use than the old debug protocol.