### PR TITLE
Update README to mark inline Swagger as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ sam local invoke --docker-volume-basedir /c/Users/shlee322/projects/test "Rating
   - [ ] `dotnetcore1.0`
 * [x] AWS credential support 
 * [x] Debugging support
-* [ ] Inline Swagger support within SAM templates
+* [x] Inline Swagger support within SAM templates
 
 ## Contributing
 


### PR DESCRIPTION
[Release notes for 0.2.3](https://github.com/awslabs/aws-sam-local/releases/tag/v0.2.3) included this line:

> Support for AWS::Serverless::Api resources, including defining your API with inline swagger

This means that the "Inline Swagger support within SAM templates" item under "Project Status" is done, right? Or is there more to it?