### PR TITLE
Allow debugger args to be passed to Python3.6 functions

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -502,6 +502,12 @@ func (r *Runtime) getDebugEntrypoint() (overrides []string) {
 		}
 		overrides = append(overrides, debuggerArgsArray...)
 		overrides = append(overrides, "/var/runtime/awslambda/bootstrap.py")
+	case runtimeName.python36:
+		overrides = []string{
+			"/var/lang/bin/python3.6",
+		}
+		overrides = append(overrides, debuggerArgsArray...)
+		overrides = append(overrides, "/var/runtime/awslambda/bootstrap.py")
 	}
 	return
 }


### PR DESCRIPTION
Adds Python3.6 to debug overrides section of `runtime.go`.