### PR TITLE
Fix node debugger protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ $ sam local invoke -d 5858 <function logical id>
 $ sam local start-api -d 5858
 ```
 
-Note: If using `sam local start-api`, the local API Gateway will expose all of your lambda functions but, since you can specify a single debug port, you can only debug one function at a time. You will need to hit your api before Sam Local binds to the port allowing the debugger to connect.
+Note: If using `sam local start-api`, the local API Gateway will expose all of your Lambda functions but, since you can specify a single debug port, you can only debug one function at a time. You will need to hit your API before SAM Local binds to the port allowing the debugger to connect.
 
 Here is an example showing how to debug a NodeJS function with Microsoft Visual Studio Code:
 
@@ -249,13 +249,13 @@ In order to setup Visual Studio Code for debugging with AWS SAM Local, use the f
             "port": 5858,
             "localRoot": "${workspaceRoot}",
             "remoteRoot": "/var/task",
-            "protocol": "inspector"
+            "protocol": "legacy"
         }
     ]
 }
 ``` 
 
-Note: You must detach your debugger in order for the result to be sent back to AWS SAM Local.
+Note: Node.js versions **below** 7 (e.g. Node.js 4.3 and Node.js 6.10) use the `legacy` protocol, while Node.js versions including and above 7 (e.g. Node.js 8.10) use the `inspector` protocol. Be sure to specify the corresponding protocol in the `protocol` entry of your launch configuration.
 
 #### Debugging Python functions
 

--- a/runtime.go
+++ b/runtime.go
@@ -510,8 +510,9 @@ func (r *Runtime) getDebugEntrypoint() (overrides []string) {
 		}
 		overrides = append(overrides, debuggerArgsArray...)
 		overrides = append(overrides,
-			"--inspect="+r.DebugPort,
-			"--debug-brk",
+			// Node8 requires the host to be explicitly set in order to bind to localhost instead of 127.0.0.1
+			// https://github.com/nodejs/node/issues/11591#issuecomment-283110138
+			"--inspect-brk=0.0.0.0:"+r.DebugPort,
 			"--nolazy",
 			"--expose-gc",
 			"--max-semi-space-size=150",

--- a/runtime.go
+++ b/runtime.go
@@ -496,8 +496,7 @@ func (r *Runtime) getDebugEntrypoint() (overrides []string) {
 		}
 		overrides = append(overrides, debuggerArgsArray...)
 		overrides = append(overrides,
-			"--inspect="+r.DebugPort,
-			"--debug-brk",
+			"--debug-brk="+r.DebugPort,
 			"--nolazy",
 			"--max-old-space-size=2547",
 			"--max-semi-space-size=150",


### PR DESCRIPTION
*Issue #, if available:*
Pertains to [this comment](https://github.com/awslabs/aws-sam-local/pull/285#issuecomment-376993161) made on [this PR](https://github.com/awslabs/aws-sam-local/pull/285).

*Description of changes:*
Changes the run command for Node.js version 6.10 to use the legacy debugger (as it previously did) instead of the inspector debugger. Includes directions in the README for when to use legacy and when to use inspector in your launch configuration in VSCode.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
